### PR TITLE
Fix `infinite` sign-out loop on auth token expiration sign-out request

### DIFF
--- a/src/actionCreators.ts
+++ b/src/actionCreators.ts
@@ -235,7 +235,16 @@ function sendSignOut(dispatch: Dispatch) {
   return api.sessions
     .destroySession()
     .then(() => dispatch(receiveSignoutSuccess()))
-    .catch(curryErrorHandler(dispatch, AuthActionType.RECEIVE_SIGNIN_ERROR))
+    .catch((err: Error) => {
+      if (err instanceof jsonapi.AuthenticationError) {
+        // If it is an auth error, it means the auth token has expired
+        // we can safely redirect to the sign-in page as a result
+        dispatch(receiveSignoutSuccess())
+        return
+      }
+
+      dispatch(createErrorAction(err, AuthActionType.RECEIVE_SIGNIN_ERROR))
+    })
 }
 
 // Base64 to ArrayBuffer


### PR DESCRIPTION
## Description

There's a bug that after a failed sign-out due to an authorization error, it retries to perform the sign out until it succeeds, or the rate limiter hits. This can happen when the user session has expired and you try to sign-out.

This PR fixes the issue.

## Steps to Test

1. Set your CL node's `SESSION_TIMEOUT` env var to `1s`
2. Log into the UI
3. Wait a second
4. Try to sign out
5. Check web console and CL node console
6. No error should be displayed
7. You should be redirected to the sign-in page

# Checklist

If this PR creates changes to the operator-ui itself, rather than tests, pipeline changes, etc. Then please create a changeset so that a new release is created, and the changelog is updated. See: https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md#what-is-a-changeset

- [x] This PR has an accompanying changeset if needed. (Doesn't need a changeset)
