### PR TITLE
Fixes task run status display for `ethtx` type

### DIFF
--- a/.changeset/green-otters-pull.md
+++ b/.changeset/green-otters-pull.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': patch
+---
+
+Fixes task run status display for unfinished tasks

--- a/src/screens/JobRun/JobRunView.tsx
+++ b/src/screens/JobRun/JobRunView.tsx
@@ -59,15 +59,24 @@ export const JobRunView = ({ run }: Props) => {
 
   // Generate a list of attributes which will get added to the stratify array.
   // We do this so we can display the correct status icon in the TaskList DAG
-  const attrs = run.taskRuns.reduce(
-    (acc, run) => ({
+  const attrs = run.taskRuns.reduce((acc, run) => {
+    let status: TaskRunStatus
+
+    if (run.error) {
+      status = TaskRunStatus.ERROR
+    } else if (run.output == 'null') {
+      status = TaskRunStatus.PENDING
+    } else {
+      status = TaskRunStatus.COMPLETE
+    }
+
+    return {
       ...acc,
       [run.dotID]: {
-        status: run.error ? TaskRunStatus.ERROR : TaskRunStatus.COMPLETE,
+        status,
       },
-    }),
-    {},
-  )
+    }
+  }, {})
 
   return (
     <Content>

--- a/src/screens/JobRun/TaskRunItem.test.tsx
+++ b/src/screens/JobRun/TaskRunItem.test.tsx
@@ -40,4 +40,19 @@ describe('TaskRunItemCard', () => {
     expect(queryByText(run.error as string)).toBeInTheDocument()
     expect(queryByText(': result,data')).toBeInTheDocument()
   })
+
+  it('renders details of the pending task run', async () => {
+    const run = buildTaskRun({
+      error: null,
+      output: 'null',
+    })
+
+    renderComponent({ ...run, attrs: { type: run.type, path: 'result,data' } })
+
+    // The pending icon
+    expect(queryByTestId('pending-run-icon')).toBeInTheDocument()
+    expect(queryByText(run.dotID)).toBeInTheDocument()
+    expect(queryByText(run.type)).toBeInTheDocument()
+    expect(queryByText(': result,data')).toBeInTheDocument()
+  })
 })

--- a/src/screens/JobRun/TaskRunItem.tsx
+++ b/src/screens/JobRun/TaskRunItem.tsx
@@ -1,15 +1,10 @@
 import React from 'react'
 
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from '@material-ui/core/styles'
+import {createStyles, Theme, withStyles, WithStyles,} from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
 
-import { TaskRunStatusIcon } from 'src/components/Icons/TaskRunStatusIcon'
-import { TaskRunStatus } from 'src/utils/taskRunStatus'
+import {TaskRunStatusIcon} from 'src/components/Icons/TaskRunStatusIcon'
+import {TaskRunStatus} from 'src/utils/taskRunStatus'
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -49,7 +44,15 @@ export interface Props
 
 export const TaskRunItem = withStyles(styles)(
   ({ attrs, classes, dotID, output, error, type }: Props) => {
-    const status = error ? TaskRunStatus.ERROR : TaskRunStatus.COMPLETE
+    let status: TaskRunStatus
+
+    if (error) {
+      status = TaskRunStatus.ERROR
+    } else if (output == 'null') {
+      status = TaskRunStatus.PENDING
+    } else {
+      status = TaskRunStatus.COMPLETE
+    }
 
     return (
       <div className={classes.root}>


### PR DESCRIPTION
## Description

Fixes task run status display for `ethtx` type.

## Steps to Test

1. Run the Operator UI with a CL node running
2. Setup a simple Job to request ethereum prices
3. Trigger the job run from the corresponding smart contract
4. Verify that in the UI, the `ethtx` task run is pending until it is confirmed
5. Or you can just follow the official guide: https://docs.chain.link/docs/fulfilling-requests/

Here's a screenshot displaying how it should look like: 
<img width="1656" alt="Screen Shot 2022-10-04 at 11 39 09 PM" src="https://user-images.githubusercontent.com/8971713/193978371-a7c87099-672b-4165-b3c2-5c982f002dc2.png">

# Checklist

If this PR creates changes to the operator-ui itself, rather than tests, pipeline changes, etc. Then please create a changeset so that a new release is created, and the changelog is updated. See: https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md#what-is-a-changeset

- [x] This PR has an accompanying changeset if needed.
