### PR TITLE
drop ID and Created from Chains and Nodes

### DIFF
--- a/src/pages/Chains/NodeRow.tsx
+++ b/src/pages/Chains/NodeRow.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 
 import { NodeResource } from './ChainNodes'
 import { tableStyles } from 'components/Table'
-import { TimeAgo } from 'components/TimeAgo'
 import Link from 'components/Link'
 
 import { withStyles, WithStyles } from '@material-ui/core/styles'
@@ -14,23 +13,15 @@ interface Props extends WithStyles<typeof tableStyles> {
 }
 
 export const NodeRow = withStyles(tableStyles)(({ node, classes }: Props) => {
-  const createdAt = node.attributes.createdAt
-
   return (
     <TableRow className={classes.row} hover>
       <TableCell className={classes.cell} component="th" scope="row">
-        <Link className={classes.link} href={`/nodes/${node.id}`}>
-          {node.id}
+        <Link className={classes.link} href={`/nodes/${node.attributes.name}`}>
+          {node.attributes.name}
         </Link>
       </TableCell>
 
-      <TableCell>{node.attributes.name}</TableCell>
-
       <TableCell>{node.attributes.evmChainID}</TableCell>
-
-      <TableCell>
-        <TimeAgo tooltip>{createdAt}</TimeAgo>
-      </TableCell>
 
       <TableCell>{node.attributes.state}</TableCell>
     </TableRow>

--- a/src/pages/Chains/NodesList.tsx
+++ b/src/pages/Chains/NodesList.tsx
@@ -21,11 +21,6 @@ const List = ({ nodes, nodeFilter }: Props) => {
     <Table>
       <TableHead>
         <TableRow>
-          <TableCell>
-            <Typography variant="body1" color="textSecondary">
-              ID
-            </Typography>
-          </TableCell>
 
           <TableCell>
             <Typography variant="body1" color="textSecondary">
@@ -36,12 +31,6 @@ const List = ({ nodes, nodeFilter }: Props) => {
           <TableCell>
             <Typography variant="body1" color="textSecondary">
               EVM Chain ID
-            </Typography>
-          </TableCell>
-
-          <TableCell>
-            <Typography variant="body1" color="textSecondary">
-              Created
             </Typography>
           </TableCell>
 

--- a/src/screens/Chains/ChainRow.test.tsx
+++ b/src/screens/Chains/ChainRow.test.tsx
@@ -34,7 +34,6 @@ describe('ChainRow', () => {
 
     expect(queryByText('5')).toBeInTheDocument()
     expect(queryByText('true')).toBeInTheDocument()
-    expect(queryByText('1 minute ago')).toBeInTheDocument()
   })
 
   it('links to the row details', async () => {

--- a/src/screens/Chains/ChainRow.tsx
+++ b/src/screens/Chains/ChainRow.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { tableStyles } from 'components/Table'
-import { TimeAgo } from 'components/TimeAgo'
 import Link from 'components/Link'
 
 import { withStyles, WithStyles } from '@material-ui/core/styles'
@@ -23,9 +22,6 @@ export const ChainRow = withStyles(tableStyles)(({ chain, classes }: Props) => {
 
       <TableCell>{chain.enabled.toString()}</TableCell>
 
-      <TableCell>
-        <TimeAgo tooltip>{chain.createdAt}</TimeAgo>
-      </TableCell>
     </TableRow>
   )
 })

--- a/src/screens/Chains/ChainsView.test.tsx
+++ b/src/screens/Chains/ChainsView.test.tsx
@@ -27,7 +27,6 @@ describe('ChainsView', () => {
 
     expect(queryByText('Chain ID')).toBeInTheDocument()
     expect(queryByText('Enabled')).toBeInTheDocument()
-    expect(queryByText('Created')).toBeInTheDocument()
 
     expect(queryByText('5')).toBeInTheDocument()
     expect(queryByText('42')).toBeInTheDocument()

--- a/src/screens/Chains/ChainsView.tsx
+++ b/src/screens/Chains/ChainsView.tsx
@@ -104,7 +104,6 @@ export const ChainsView: React.FC<Props> = ({
                 <TableRow>
                   <TableCell>Chain ID</TableCell>
                   <TableCell>Enabled</TableCell>
-                  <TableCell>Created</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>

--- a/src/screens/Node/NodeCard.test.tsx
+++ b/src/screens/Node/NodeCard.test.tsx
@@ -24,11 +24,9 @@ describe('NodeCard', () => {
 
     renderComponent(node)
 
-    expect(queryByText(node.id)).toBeInTheDocument()
     expect(queryByText(node.chain.id)).toBeInTheDocument()
     expect(queryByText(node.httpURL)).toBeInTheDocument()
     expect(queryByText(node.wsURL)).toBeInTheDocument()
-    expect(queryByText('1 minute ago')).toBeInTheDocument()
   })
 
   it('calls delete', () => {

--- a/src/screens/Node/NodeCard.tsx
+++ b/src/screens/Node/NodeCard.tsx
@@ -14,7 +14,6 @@ import {
   DetailsCardItemTitle,
   DetailsCardItemValue,
 } from 'src/components/Cards/DetailsCard'
-import { TimeAgo } from 'src/components/TimeAgo'
 
 interface Props {
   node: NodePayload_Fields
@@ -60,21 +59,10 @@ export const NodeCard: React.FC<Props> = ({ node, onDelete }) => {
       }
     >
       <Grid container>
-        <Grid item xs={12} sm={4} md={3}>
-          <DetailsCardItemTitle title="ID" />
-          <DetailsCardItemValue value={node.id} />
-        </Grid>
 
         <Grid item xs={12} sm={4} md={3}>
           <DetailsCardItemTitle title="EVM Chain ID" />
           <DetailsCardItemValue value={node.chain.id} />
-        </Grid>
-
-        <Grid item xs={12} sm={4} md={2}>
-          <DetailsCardItemTitle title="Created" />
-          <DetailsCardItemValue>
-            <TimeAgo tooltip>{node.createdAt}</TimeAgo>
-          </DetailsCardItemValue>
         </Grid>
 
         <Grid item xs={false} sm={false} md={4}></Grid>

--- a/src/screens/Node/NodeView.test.tsx
+++ b/src/screens/Node/NodeView.test.tsx
@@ -24,8 +24,6 @@ describe('NodeView', () => {
     renderComponent(node)
 
     expect(getByRole('heading', { name: node.name })).toBeInTheDocument()
-    expect(getByText('ID')).toBeInTheDocument()
-    expect(getByText(node.id)).toBeInTheDocument()
   })
 
   it('handles opens a confirmation modal and handles delete', async () => {

--- a/src/screens/Nodes/NodeRow.test.tsx
+++ b/src/screens/Nodes/NodeRow.test.tsx
@@ -32,10 +32,8 @@ describe('NodeRow', () => {
 
     renderComponent(node)
 
-    expect(queryByText('1')).toBeInTheDocument()
     expect(queryByText('node1')).toBeInTheDocument()
     expect(queryByText('42')).toBeInTheDocument()
-    expect(queryByText('1 minute ago')).toBeInTheDocument()
   })
 
   it('links to the row details', async () => {
@@ -44,7 +42,7 @@ describe('NodeRow', () => {
     renderComponent(node)
 
     const link = getByRole('link', { name: /1/i })
-    expect(link).toHaveAttribute('href', '/nodes/1')
+    expect(link).toHaveAttribute('href', '/nodes/node1')
 
     userEvent.click(link)
 

--- a/src/screens/Nodes/NodeRow.tsx
+++ b/src/screens/Nodes/NodeRow.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { tableStyles } from 'components/Table'
-import { TimeAgo } from 'components/TimeAgo'
 import Link from 'components/Link'
 
 import { withStyles, WithStyles } from '@material-ui/core/styles'
@@ -16,16 +15,11 @@ export const NodeRow = withStyles(tableStyles)(({ node, classes }: Props) => {
   return (
     <TableRow className={classes.row} hover>
       <TableCell className={classes.cell} component="th" scope="row">
-        <Link className={classes.link} href={`/nodes/${node.id}`}>
-          {node.id}
+        <Link className={classes.link} href={`/nodes/${node.name}`}>
+          {node.name}
         </Link>
       </TableCell>
-
-      <TableCell>{node.name}</TableCell>
       <TableCell>{node.chain.id}</TableCell>
-      <TableCell>
-        <TimeAgo tooltip>{node.createdAt}</TimeAgo>
-      </TableCell>
       <TableCell>{node.state}</TableCell>
     </TableRow>
   )

--- a/src/screens/Nodes/NodesView.test.tsx
+++ b/src/screens/Nodes/NodesView.test.tsx
@@ -25,13 +25,8 @@ describe('NodesView', () => {
 
     expect(getAllByRole('row')).toHaveLength(3)
 
-    expect(queryByText('ID')).toBeInTheDocument()
     expect(queryByText('Name')).toBeInTheDocument()
     expect(queryByText('EVM Chain ID')).toBeInTheDocument()
-    expect(queryByText('Created')).toBeInTheDocument()
-
-    expect(queryByText('1')).toBeInTheDocument()
-    expect(queryByText('2')).toBeInTheDocument()
 
     expect(queryByText('1-2 of 2'))
   })
@@ -60,20 +55,13 @@ describe('NodesView', () => {
     userEvent.paste(searchInput, 'node1')
 
     expect(getAllByRole('row')).toHaveLength(2)
-    expect(queryByText('1')).toBeInTheDocument()
-
-    // By id
-    userEvent.clear(searchInput)
-    userEvent.paste(searchInput, '1')
-
-    expect(getAllByRole('row')).toHaveLength(2)
-    expect(queryByText('1')).toBeInTheDocument()
+    expect(queryByText('node1')).toBeInTheDocument()
 
     // By EVM ID
     userEvent.clear(searchInput)
     userEvent.paste(searchInput, '5')
 
     expect(getAllByRole('row')).toHaveLength(2)
-    expect(queryByText('2')).toBeInTheDocument()
+    expect(queryByText('node2')).toBeInTheDocument()
   })
 })

--- a/src/screens/Nodes/NodesView.tsx
+++ b/src/screens/Nodes/NodesView.tsx
@@ -94,10 +94,8 @@ export const NodesView: React.FC<Props> = ({
             <Table>
               <TableHead>
                 <TableRow>
-                  <TableCell>ID</TableCell>
                   <TableCell>Name</TableCell>
                   <TableCell>EVM Chain ID</TableCell>
-                  <TableCell>Created</TableCell>
                   <TableCell>State</TableCell>
                 </TableRow>
               </TableHead>


### PR DESCRIPTION
## Description

With new config, Chains and Nodes no longer have integer database IDs or 'Created' timestamps. This change removes them from view, substituting `Name` for a unique Node identifier.

![Screenshot from 2022-10-31 07-23-12](https://user-images.githubusercontent.com/1194128/199007013-a3db31c0-96fc-4d8d-9a25-734af4c2ac62.png)
![Screenshot from 2022-10-31 07-23-22](https://user-images.githubusercontent.com/1194128/199007012-b8678e66-b6aa-4bc3-9aab-fea9654f9f63.png)
![Screenshot from 2022-10-31 07-23-35](https://user-images.githubusercontent.com/1194128/199007002-c1afc6d1-2c60-4e3f-b491-4de8c922820c.png)