### PR TITLE
Remove ID attribute from bootstrap job spec

### DIFF
--- a/src/screens/Job/JobView.tsx
+++ b/src/screens/Job/JobView.tsx
@@ -107,7 +107,6 @@ const JOB_PAYLOAD__SPEC = gql`
       fromAddress
     }
     ... on BootstrapSpec {
-      id
       contractID
       relay
       monitoringEndpoint

--- a/src/screens/Job/generateJobDefinition.test.ts
+++ b/src/screens/Job/generateJobDefinition.test.ts
@@ -543,7 +543,6 @@ observationSource = """
       gasLimit: 1000,
       spec: {
         __typename: 'BootstrapSpec',
-        id: '',
         contractID: '0x0000000000000000000000000000000000000000',
         relay: 'evm',
         relayConfig: {
@@ -564,7 +563,6 @@ schemaVersion = 1
 name = "bootstrap"
 externalJobID = "00000000-0000-0000-0000-0000000000001"
 gasLimit = 1_000
-id = ""
 contractID = "0x0000000000000000000000000000000000000000"
 relay = "evm"
 monitoringEndpoint = "https://monitoring.endpoint"

--- a/src/screens/Job/generateJobDefinition.ts
+++ b/src/screens/Job/generateJobDefinition.ts
@@ -245,7 +245,6 @@ export const generateJobDefinition = (
         ...extractJobFields(job),
         ...extractSpecFields(
           job.spec,
-          'id',
           'contractID',
           'relay',
           'relayConfig',


### PR DESCRIPTION
## Description

ID is internal to the DB and shouldn't be part of the displayed job spec. It was mistakenly added in https://github.com/smartcontractkit/chainlink/pull/5882

## Steps to Test

1. `yarn && yarn setup`
2. `yarn start`
3. Go to jobs -> new job -> create a job of type bootstrap and save it. Then load its definition and verify there is no "id" field listed there.
