### PR TITLE
screens/Job: add gasLanePrice to VRFSpec query

### DIFF
--- a/src/screens/Job/JobView.tsx
+++ b/src/screens/Job/JobView.tsx
@@ -80,6 +80,7 @@ const JOB_PAYLOAD__SPEC = gql`
     }
     ... on VRFSpec {
       evmChainID
+      gasLanePrice
       coordinatorAddress
       fromAddresses
       minIncomingConfirmations

--- a/src/screens/Job/generateJobDefinition.test.ts
+++ b/src/screens/Job/generateJobDefinition.test.ts
@@ -461,6 +461,7 @@ juelsPerFeeCoinSource = "1000000000"
         chunkSize: 25,
         backoffInitialDelay: '1m',
         backoffMaxDelay: '1h',
+        gasLanePrice: '200 gwei',
       },
       observationSource:
         '    fetch    [type=http method=POST url="http://localhost:8001" requestData="{\\"hi\\": \\"hello\\"}"];\n    parse    [type=jsonparse path="data,result"];\n    multiply [type=multiply times=100];\n    fetch -> parse -> multiply;\n',
@@ -486,6 +487,7 @@ batchFulfillmentGasMultiplier = 1
 chunkSize = 25
 backoffInitialDelay = "1m"
 backoffMaxDelay = "1h"
+gasLanePrice = "200 gwei"
 observationSource = """
     fetch    [type=http method=POST url="http://localhost:8001" requestData="{\\\\"hi\\\\": \\\\"hello\\\\"}"];
     parse    [type=jsonparse path="data,result"];

--- a/src/screens/Job/generateJobDefinition.ts
+++ b/src/screens/Job/generateJobDefinition.ts
@@ -215,6 +215,7 @@ export const generateJobDefinition = (
           'chunkSize',
           'backoffInitialDelay',
           'backoffMaxDelay',
+          'gasLanePrice',
         ),
         ...extractObservationSourceField(job),
       }


### PR DESCRIPTION
## Description

Add [`gasLanePrice`](https://github.com/smartcontractkit/chainlink/blob/develop/core/web/schema/type/spec.graphql#L111) to the `VRFSpec` query. This is so that `gasLanePrice` is correctly rendered in the job details page for VRF v2 jobs.

## Steps to Test

1. Spin up a CL node.
2. Create a VRF job with `gasLanePrice` correctly specified (e.g `"200 gwei"`)
3. Verify that `gasLanePrice = "200 gwei"` is correctly rendered in the VRF job details UI.

# Checklist

- [ ] This PR has an accompanying changeset if needed.
