### PR TITLE
Display the Feeds Manager navigation link in mobile view drawer

### DIFF
--- a/.changeset/sweet-turkeys-mate.md
+++ b/.changeset/sweet-turkeys-mate.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': minor
+---
+
+Display the Feeds Manager navigation in the mobile navigation drawer


### PR DESCRIPTION
## Description

Adds the Feeds Manager navigation link to display in the Navigation Drawer when on mobile view

## Steps to Test

Ensure Feeds Manager is enabled via your env vars

1. Login to the Operator UI
2. View a page in mobile view
3. Open the navigation drawer
4. You should see the Feeds Manager link which will navigate you to the feeds manager page
5. 

# Checklist

- [ ] This PR has an accompanying changeset if needed.


https://user-images.githubusercontent.com/61834/202719365-72a53fc9-9421-404c-a01f-5cb966ce8175.mov


