### PR TITLE
dynamic config for legacy vs. TOML

### DIFF
--- a/src/screens/Configuration/ConfigurationCard/ConfigurationCard.tsx
+++ b/src/screens/Configuration/ConfigurationCard/ConfigurationCard.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { gql, useQuery } from '@apollo/client'
 
 import { KeyValueListCard } from 'src/components/Cards/KeyValueListCard'
+import {isNil} from "lodash";
 
 export const CONFIG__ITEMS_FIELDS = gql`
   fragment Config_ItemsFields on ConfigItem {
@@ -48,7 +49,7 @@ export const ConfigurationCard = () => {
       error={error?.message}
       loading={loading}
       entries={entries}
-      showHead
+      showHead={isNil(error?.message)}
     />
   )
 }

--- a/src/screens/Configuration/ConfigurationCard/ConfigurationCard.tsx
+++ b/src/screens/Configuration/ConfigurationCard/ConfigurationCard.tsx
@@ -44,7 +44,7 @@ export const ConfigurationCard = () => {
 
   return (
     <KeyValueListCard
-      title="ENV Configuration (legacy)"
+      title="ENV Configuration"
       error={error?.message}
       loading={loading}
       entries={entries}

--- a/src/screens/Configuration/ConfigurationV2Card/ConfigurationV2Card.tsx
+++ b/src/screens/Configuration/ConfigurationV2Card/ConfigurationV2Card.tsx
@@ -8,6 +8,9 @@ import TableCell from '@material-ui/core/TableCell'
 import TableRow from '@material-ui/core/TableRow'
 import Grid from '@material-ui/core/Grid'
 
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { prism } from 'react-syntax-highlighter/dist/esm/styles/prism'
+
 export const CONFIG_V2_QUERY = gql`
   query FetchConfigV2 {
     configv2 {
@@ -29,7 +32,7 @@ export const ConfigurationV2Card = () => {
       <>
         <Grid item xs={12}>
           <TOMLCard
-            title="TOML Configuration (config dump)"
+            title="TOML Configuration (v2 config dump)"
             error={error?.message}
             loading={loading}
             toml={data?.configv2.user}
@@ -93,14 +96,13 @@ const TOMLCard = ({ loading, toml, error = '', title }: Props) => {
     return <FetchingRow />
   }
 
-  const styles = { marginLeft: '1em' }
-
+    //TODO expandable, start collapsed should be possible
   return (
     <Card>
       {title && <CardHeader title={title} />}
-      <pre style={styles}>
-        <code>{toml}</code>
-      </pre>
+      <SyntaxHighlighter language="toml" style={prism}>
+        {toml}
+      </SyntaxHighlighter>
     </Card>
   )
 }

--- a/src/screens/Configuration/ConfigurationV2Card/ConfigurationV2Card.tsx
+++ b/src/screens/Configuration/ConfigurationV2Card/ConfigurationV2Card.tsx
@@ -24,6 +24,22 @@ export const ConfigurationV2Card = () => {
     fetchPolicy: 'cache-and-network',
   })
 
+  if (data?.configv2.effective == 'N/A') {
+    return (
+      <>
+        <Grid item xs={12}>
+          <TOMLCard
+            title="TOML Configuration (config dump)"
+            error={error?.message}
+            loading={loading}
+            toml={data?.configv2.user}
+            showHead
+          />
+        </Grid>
+      </>
+    )
+  }
+
   return (
     <>
       <Grid item xs={12}>
@@ -77,14 +93,14 @@ const TOMLCard = ({ loading, toml, error = '', title }: Props) => {
     return <FetchingRow />
   }
 
-  let styles = {marginLeft: '1em'};
+  const styles = { marginLeft: '1em' }
 
   return (
     <Card>
       {title && <CardHeader title={title} />}
-        <pre style={styles}>
-          <code>{toml}</code>
-        </pre>
+      <pre style={styles}>
+        <code>{toml}</code>
+      </pre>
     </Card>
   )
 }

--- a/src/screens/Configuration/ConfigurationV2Card/ConfigurationV2Card.tsx
+++ b/src/screens/Configuration/ConfigurationV2Card/ConfigurationV2Card.tsx
@@ -7,9 +7,13 @@ import CardHeader from '@material-ui/core/CardHeader'
 import TableCell from '@material-ui/core/TableCell'
 import TableRow from '@material-ui/core/TableRow'
 import Grid from '@material-ui/core/Grid'
+import ExpansionPanel from '@material-ui/core/ExpansionPanel'
+import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary'
+import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails'
 
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { prism } from 'react-syntax-highlighter/dist/esm/styles/prism'
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 
 export const CONFIG_V2_QUERY = gql`
   query FetchConfigV2 {
@@ -31,13 +35,16 @@ export const ConfigurationV2Card = () => {
     return (
       <>
         <Grid item xs={12}>
-          <TOMLCard
-            title="TOML Configuration (v2 config dump)"
-            error={error?.message}
-            loading={loading}
-            toml={data?.configv2.user}
-            showHead
-          />
+          <Card>
+            <CardHeader title="TOML Configuration" />
+            <TOMLPanel
+              title="v2 config dump"
+              error={error?.message}
+              loading={loading}
+              toml={data?.configv2.user}
+              showHead
+            />
+          </Card>
         </Grid>
       </>
     )
@@ -46,22 +53,24 @@ export const ConfigurationV2Card = () => {
   return (
     <>
       <Grid item xs={12}>
-        <TOMLCard
-          title="TOML Configuration (user-specified)"
-          error={error?.message}
-          loading={loading}
-          toml={data?.configv2.user}
-          showHead
-        />
-      </Grid>
-      <Grid item xs={12}>
-        <TOMLCard
-          title="TOML Configuration (effective)"
-          error={error?.message}
-          loading={loading}
-          toml={data?.configv2.effective}
-          showHead
-        />
+        <Card>
+          <CardHeader title="TOML Configuration" />
+          <TOMLPanel
+            title="User specified:"
+            error={error?.message}
+            loading={loading}
+            toml={data?.configv2.user}
+            showHead
+            expanded={true}
+          />
+          <TOMLPanel
+            title="Effective (with defaults):"
+            error={error?.message}
+            loading={loading}
+            toml={data?.configv2.effective}
+            showHead
+          />
+        </Card>
       </Grid>
     </>
   )
@@ -73,6 +82,7 @@ interface Props {
   showHead?: boolean
   title?: string
   error?: string
+  expanded?: boolean
 }
 
 const SpanRow: React.FC = ({ children }) => (
@@ -87,7 +97,7 @@ const FetchingRow = () => <SpanRow>...</SpanRow>
 
 const ErrorRow: React.FC = ({ children }) => <SpanRow>{children}</SpanRow>
 
-const TOMLCard = ({ loading, toml, error = '', title }: Props) => {
+const TOMLPanel = ({ loading, toml, error = '', title, expanded }: Props) => {
   if (error) {
     return <ErrorRow>{error}</ErrorRow>
   }
@@ -96,13 +106,22 @@ const TOMLCard = ({ loading, toml, error = '', title }: Props) => {
     return <FetchingRow />
   }
 
-    //TODO expandable, start collapsed should be possible
+  if (!title) {
+    title = 'TOML'
+  }
+
+  const styles = { display: 'block' }
+
   return (
-    <Card>
-      {title && <CardHeader title={title} />}
-      <SyntaxHighlighter language="toml" style={prism}>
-        {toml}
-      </SyntaxHighlighter>
-    </Card>
+    <ExpansionPanel defaultExpanded={expanded}>
+      <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+        {title}
+      </ExpansionPanelSummary>
+      <ExpansionPanelDetails style={styles}>
+        <SyntaxHighlighter language="toml" style={prism}>
+          {toml}
+        </SyntaxHighlighter>
+      </ExpansionPanelDetails>
+    </ExpansionPanel>
   )
 }

--- a/src/screens/Configuration/ConfigurationV2Card/ConfigurationV2Card.tsx
+++ b/src/screens/Configuration/ConfigurationV2Card/ConfigurationV2Card.tsx
@@ -14,6 +14,7 @@ import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { prism } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
+import Typography from '@material-ui/core/Typography'
 
 export const CONFIG_V2_QUERY = gql`
   query FetchConfigV2 {
@@ -38,7 +39,7 @@ export const ConfigurationV2Card = () => {
           <Card>
             <CardHeader title="TOML Configuration" />
             <TOMLPanel
-              title="v2 config dump"
+              title="V2 config dump:"
               error={error?.message}
               loading={loading}
               toml={data?.configv2.user}
@@ -113,15 +114,17 @@ const TOMLPanel = ({ loading, toml, error = '', title, expanded }: Props) => {
   const styles = { display: 'block' }
 
   return (
-    <ExpansionPanel defaultExpanded={expanded}>
-      <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-        {title}
-      </ExpansionPanelSummary>
-      <ExpansionPanelDetails style={styles}>
-        <SyntaxHighlighter language="toml" style={prism}>
-          {toml}
-        </SyntaxHighlighter>
-      </ExpansionPanelDetails>
-    </ExpansionPanel>
+    <Typography>
+      <ExpansionPanel defaultExpanded={expanded}>
+        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+          {title}
+        </ExpansionPanelSummary>
+        <ExpansionPanelDetails style={styles}>
+          <SyntaxHighlighter language="toml" style={prism}>
+            {toml}
+          </SyntaxHighlighter>
+        </ExpansionPanelDetails>
+      </ExpansionPanel>
+    </Typography>
   )
 }

--- a/src/screens/Configuration/ConfigurationView.test.tsx
+++ b/src/screens/Configuration/ConfigurationView.test.tsx
@@ -18,7 +18,7 @@ describe('ConfigurationView', () => {
       </BuildInfoProvider>,
     )
 
-    expect(await findByText('ENV Configuration (legacy)')).toBeInTheDocument()
+    expect(await findByText('ENV Configuration')).toBeInTheDocument()
     expect(await findByText('Node')).toBeInTheDocument()
     expect(await findByText('Job Runs')).toBeInTheDocument()
     expect(await findByText('Logging')).toBeInTheDocument()


### PR DESCRIPTION
This change updates the config screen to be more user friendly and dynamic with legacy vs. TOML.

1. Removed the `(legacy)` suffix from ENV, let the error speak for itself when using TOML:
![Screenshot from 2022-11-29 20-02-04](https://user-images.githubusercontent.com/1194128/204690108-14db27c6-d477-4d9e-8f8c-80944deedb7e.png)

2. When legacy config is in use, show only the dumped TOML, with an alternative title:
![Screenshot from 2022-11-29 20-11-34](https://user-images.githubusercontent.com/1194128/204690639-35ce0646-827b-41b2-a2b9-a7047fd16d45.png)

