### PR TITLE
Changed "ETH balance" with "Native token balance" 

### DIFF
--- a/.changeset/silly-jokes-lay.md
+++ b/.changeset/silly-jokes-lay.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': minor
+---
+
+Replaced "ETH balance" with "Native token balance"

--- a/src/screens/Dashboard/AccountBalanceCard.tsx
+++ b/src/screens/Dashboard/AccountBalanceCard.tsx
@@ -72,7 +72,7 @@ export const AccountBalanceCard: React.FC<Props> = ({
               </Grid>
 
               <Grid item xs={6}>
-                <DetailsCardItemTitle title="ETH Balance" />
+                <DetailsCardItemTitle title="Native Token Balance" />
                 <DetailsCardItemValue value={ethKey.ethBalance || '--'} />
               </Grid>
 

--- a/src/screens/KeyManagement/EVMAccountsCard.test.tsx
+++ b/src/screens/KeyManagement/EVMAccountsCard.test.tsx
@@ -32,7 +32,7 @@ describe('ETHKeysCard', () => {
     expect(queryByText('Chain ID')).toBeInTheDocument()
     expect(queryAllByText('Enabled')).toHaveLength(3)
     expect(queryByText('LINK Balance')).toBeInTheDocument()
-    expect(queryByText('ETH Balance')).toBeInTheDocument()
+    expect(queryByText('Native Token Balance')).toBeInTheDocument()
     expect(queryByText('Created')).toBeInTheDocument()
 
     expect(

--- a/src/screens/KeyManagement/EVMAccountsCard.tsx
+++ b/src/screens/KeyManagement/EVMAccountsCard.tsx
@@ -37,7 +37,7 @@ export const EVMAccountsCard: React.FC<Props> = ({
             <TableCell>Chain ID</TableCell>
             <TableCell>Enabled</TableCell>
             <TableCell>LINK Balance</TableCell>
-            <TableCell>ETH Balance</TableCell>
+            <TableCell>Native Token Balance</TableCell>
             <TableCell>Created</TableCell>
             <TableCell>Actions</TableCell>
           </TableRow>


### PR DESCRIPTION
Changed "ETH balance" with "Native token balance" to be more user-friendly/less confusing on different chains

Task link: https://smartcontract-it.atlassian.net/browse/BCF-1674
Github issue: https://github.com/smartcontractkit/chainlink/issues/6784