### PR TITLE
Fixes the GQL call to handle the removal of timestamps from Node and …

### DIFF
--- a/.changeset/quick-days-cross.md
+++ b/.changeset/quick-days-cross.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': patch
+---
+
+Fixes Node and Chain GQL queries which call the `CreatedAt` field which was removed

--- a/src/hooks/queries/useChainsQuery.ts
+++ b/src/hooks/queries/useChainsQuery.ts
@@ -4,7 +4,6 @@ export const CHAINS_PAYLOAD__RESULTS_FIELDS = gql`
   fragment ChainsPayload_ResultsFields on Chain {
     id
     enabled
-    createdAt
   }
 `
 

--- a/src/screens/Node/NodeView.tsx
+++ b/src/screens/Node/NodeView.tsx
@@ -17,7 +17,6 @@ export const NODE_PAYLOAD_FIELDS = gql`
     }
     httpURL
     wsURL
-    createdAt
     state
     sendOnly
   }

--- a/src/screens/Nodes/NodesView.tsx
+++ b/src/screens/Nodes/NodesView.tsx
@@ -24,7 +24,6 @@ export const NODES_PAYLOAD__RESULTS_FIELDS = gql`
       id
     }
     name
-    createdAt
     state
     sendOnly
   }

--- a/support/factories/gql/fetchChains.ts
+++ b/support/factories/gql/fetchChains.ts
@@ -1,34 +1,25 @@
-import isoDate, { MINUTE_MS } from 'test-helpers/isoDate'
-
 // buildChains builds a chain for the FetchChains query.
 export function buildChain(
   overrides?: Partial<ChainsPayload_ResultsFields>,
 ): ChainsPayload_ResultsFields {
-  const minuteAgo = isoDate(Date.now() - MINUTE_MS)
-
   return {
     __typename: 'Chain',
     id: '5',
     enabled: true,
-    createdAt: minuteAgo,
     ...overrides,
   }
 }
 
 // buildsChains builds a list of chains.
 export function buildChains(): ReadonlyArray<ChainsPayload_ResultsFields> {
-  const minuteAgo = isoDate(Date.now() - MINUTE_MS)
-
   return [
     buildChain({
       id: '5',
       enabled: true,
-      createdAt: minuteAgo,
     }),
     buildChain({
       id: '42',
       enabled: true,
-      createdAt: minuteAgo,
     }),
   ]
 }

--- a/support/factories/gql/fetchNode.ts
+++ b/support/factories/gql/fetchNode.ts
@@ -1,18 +1,13 @@
-import isoDate, { MINUTE_MS } from 'test-helpers/isoDate'
-
 // buildNodePayloadFields builds the node fields.
 export function buildNodePayloadFields(
   overrides?: Partial<NodePayload_Fields>,
 ): NodePayload_Fields {
-  const minuteAgo = isoDate(Date.now() - MINUTE_MS)
-
   return {
     __typename: 'Node',
     id: '1',
     name: 'node1',
     httpURL: 'https://node1.com',
     wsURL: 'wss://node1.com',
-    createdAt: minuteAgo,
     chain: {
       id: '42',
     },

--- a/support/factories/gql/fetchNodes.ts
+++ b/support/factories/gql/fetchNodes.ts
@@ -1,11 +1,7 @@
-import isoDate, { MINUTE_MS } from 'test-helpers/isoDate'
-
 // buildNode builds a node for the FetchNodes query.
 export function buildNode(
   overrides?: Partial<NodesPayload_ResultsFields>,
 ): NodesPayload_ResultsFields {
-  const minuteAgo = isoDate(Date.now() - MINUTE_MS)
-
   return {
     __typename: 'Node',
     id: '1',
@@ -13,7 +9,6 @@ export function buildNode(
     chain: {
       id: '42',
     },
-    createdAt: minuteAgo,
     state: '',
     sendOnly: false,
     ...overrides,
@@ -22,8 +17,6 @@ export function buildNode(
 
 // buildNodes builds a list of nodes.
 export function buildNodes(): ReadonlyArray<NodesPayload_ResultsFields> {
-  const minuteAgo = isoDate(Date.now() - MINUTE_MS)
-
   return [
     buildNode({
       id: '1',
@@ -31,7 +24,6 @@ export function buildNodes(): ReadonlyArray<NodesPayload_ResultsFields> {
       chain: {
         id: '42',
       },
-      createdAt: minuteAgo,
     }),
     buildNode({
       id: '2',
@@ -39,7 +31,6 @@ export function buildNodes(): ReadonlyArray<NodesPayload_ResultsFields> {
       chain: {
         id: '5',
       },
-      createdAt: minuteAgo,
     }),
   ]
 }


### PR DESCRIPTION
## Description

This fixes the GQL queries which use the `CreatedAt` fields on `Node` and `Chain` which were removed.

This was preventing `yarn setup` from running

## Steps to Test

1. `yarn && yarn setup`
2. `yarn start`
3. ...etc

# Checklist

If this PR creates changes to the operator-ui itself, rather than tests, pipeline changes, etc. Then please create a changeset so that a new release is created, and the changelog is updated. See: https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md#what-is-a-changeset

- [x] This PR has an accompanying changeset if needed.
