### PR TITLE
Change decross to decrossTwoLayer

### DIFF
--- a/src/components/Cards/TaskListDAG.tsx
+++ b/src/components/Cards/TaskListDAG.tsx
@@ -56,7 +56,7 @@ function createDag({
     .sugiyama()
     .size([width - 150, height])
     .layering(d3dag.layeringSimplex())
-    .decross(d3dag.decrossOpt())
+    .decross(d3dag.decrossTwoLayer())
     .coord(d3dag.coordVert())(dag)
 
   const line = d3


### PR DESCRIPTION
Operator-UI freezes when presented with a job that has many nodes.

Issue is caused by the decrossing algorithm used when rendering the DAG
https://smartcontract-it.atlassian.net/browse/BCF-2226
