### PR TITLE
Add node order

### DIFF
--- a/.changeset/tender-trees-cover.md
+++ b/.changeset/tender-trees-cover.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': minor
+---
+
+Add order field in the `Nodes` screen

--- a/@types/core/store/models.d.ts
+++ b/@types/core/store/models.d.ts
@@ -90,6 +90,7 @@ declare module 'core/store/models' {
     createdAt: time.Time
     updatedAt: time.Time
     state: string
+    order?: number
   }
 
   export type EVMKey = {

--- a/src/screens/Node/NodeView.tsx
+++ b/src/screens/Node/NodeView.tsx
@@ -19,6 +19,7 @@ export const NODE_PAYLOAD_FIELDS = gql`
     wsURL
     state
     sendOnly
+    order
   }
 `
 

--- a/src/screens/Nodes/NodeRow.tsx
+++ b/src/screens/Nodes/NodeRow.tsx
@@ -21,7 +21,8 @@ export const NodeRow = withStyles(tableStyles)(({ node, classes }: Props) => {
       </TableCell>
       <TableCell>{node.chain.id}</TableCell>
       <TableCell>{node.state}</TableCell>
-      <TableCell>{node.sendOnly ? "SendOnly" : "Primary"}</TableCell>
+      <TableCell>{node.sendOnly ? 'SendOnly' : 'Primary'}</TableCell>
+      <TableCell>{node.order ? node.order : 'NA'}</TableCell>
     </TableRow>
   )
 })

--- a/src/screens/Nodes/NodesScreen.test.tsx
+++ b/src/screens/Nodes/NodesScreen.test.tsx
@@ -115,6 +115,8 @@ describe('NodesScreen', () => {
     expect(queryByText('node1')).toBeInTheDocument()
     expect(queryByText('node2')).toBeInTheDocument()
     expect(queryByText('1-2 of 3')).toBeInTheDocument()
+    expect(queryByText('32')).toBeInTheDocument() //Node order exists
+    expect(queryByText('NA')).toBeInTheDocument() //Node order does not exist
     expect(getByRole('button', { name: /prev-page/i })).toBeDisabled()
 
     // Page 2

--- a/src/screens/Nodes/NodesView.test.tsx
+++ b/src/screens/Nodes/NodesView.test.tsx
@@ -27,6 +27,7 @@ describe('NodesView', () => {
 
     expect(queryByText('Name')).toBeInTheDocument()
     expect(queryByText('EVM Chain ID')).toBeInTheDocument()
+    expect(queryByText('Order')).toBeInTheDocument()
 
     expect(queryByText('1-2 of 2'))
   })

--- a/src/screens/Nodes/NodesView.tsx
+++ b/src/screens/Nodes/NodesView.tsx
@@ -26,6 +26,7 @@ export const NODES_PAYLOAD__RESULTS_FIELDS = gql`
     name
     state
     sendOnly
+    order
   }
 `
 
@@ -98,6 +99,7 @@ export const NodesView: React.FC<Props> = ({
                   <TableCell>EVM Chain ID</TableCell>
                   <TableCell>State</TableCell>
                   <TableCell>Type</TableCell>
+                  <TableCell>Order</TableCell>
                 </TableRow>
               </TableHead>
 

--- a/support/factories/gql/fetchNodes.ts
+++ b/support/factories/gql/fetchNodes.ts
@@ -24,6 +24,7 @@ export function buildNodes(): ReadonlyArray<NodesPayload_ResultsFields> {
       chain: {
         id: '42',
       },
+      order: 32,
     }),
     buildNode({
       id: '2',


### PR DESCRIPTION
Add node order column in the `Nodes` screen

![Screenshot 2023-06-14 at 19 33 47](https://github.com/smartcontractkit/operator-ui/assets/120329946/0d4ca561-3a27-41b2-b47a-279010c62ac8)


GQL schema changes PR: https://github.com/smartcontractkit/chainlink/pull/9554