### PR TITLE
chore/simple-passwords-announcement: adding announcement for deprecation of simple passwords in config page

### DIFF
--- a/.changeset/tame-penguins-shake.md
+++ b/.changeset/tame-penguins-shake.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': minor
+---
+
+Adding notification for upcoming AllowSimplePasswords configuration breaking change in core v2.6.0

--- a/src/screens/Configuration/ConfigurationV2Card/ConfigurationV2Card.tsx
+++ b/src/screens/Configuration/ConfigurationV2Card/ConfigurationV2Card.tsx
@@ -68,6 +68,15 @@ const TOMLPanel = ({ loading, toml, error = '', title, expanded }: Props) => {
   )
 }
 
+const AllowSimplePasswordsNotification = () => {
+  const allowSimplePasswordsNotification = "Starting in 2.6.0, chainlink nodes will no longer AllowSimplePasswords=true for production builds. Any TOML configuration that sets the following line will fail validation checks in `node start` or `node validate`."
+  return (
+    <Card>
+      <CardHeader title={<>{allowSimplePasswordsNotification}</>} />
+  </Card>
+  )
+}
+
 export const ConfigurationV2Card = () => {
   const { data, loading, error } = useQuery<
     FetchConfigV2,
@@ -82,6 +91,7 @@ export const ConfigurationV2Card = () => {
         <Grid item xs={12}>
           <Card>
             <CardHeader title="TOML Configuration" />
+              <AllowSimplePasswordsNotification />
             <TOMLPanel
               title="V2 config dump:"
               error={error?.message}
@@ -100,6 +110,7 @@ export const ConfigurationV2Card = () => {
       <Grid item xs={12}>
         <Card>
           <CardHeader title="TOML Configuration" />
+            <AllowSimplePasswordsNotification />
           <TOMLPanel
             title="User specified:"
             error={error?.message}


### PR DESCRIPTION
## Description

Adding announcement for deprecation of simple passwords in config page

## Steps to Test

1. `yarn && yarn setup`
2. `yarn start`
3.  Login
4. Navigate to config page and view notification

# Checklist

If this PR creates changes to the operator-ui itself, rather than tests, pipeline changes, etc. Then please create a changeset so that a new release is created, and the changelog is updated. See: https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md#what-is-a-changeset

- [X ] This PR has an accompanying changeset if needed.
