### PR TITLE
add feeds manager operator forwarder support for ocr2

### DIFF
--- a/.changeset/sharp-rice-melt.md
+++ b/.changeset/sharp-rice-melt.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': patch
+---
+
+Add support for using operator forwarder in OCR2 jobs managed by FMS

--- a/src/components/Form/ChainConfigurationForm.test.tsx
+++ b/src/components/Form/ChainConfigurationForm.test.tsx
@@ -30,6 +30,7 @@ describe('ChainConfigurationForm', () => {
       ocr2ExecutePluginEnabled: false,
       ocr2MedianPluginEnabled: false,
       ocr2MercuryPluginEnabled: false,
+      ocr2ForwarderAddress: '',
     }
 
     render(
@@ -80,6 +81,7 @@ describe('ChainConfigurationForm', () => {
       ocr2ExecutePluginEnabled: false,
       ocr2MedianPluginEnabled: false,
       ocr2MercuryPluginEnabled: false,
+      ocr2ForwarderAddress: '',
     }
 
     render(
@@ -138,6 +140,7 @@ describe('ChainConfigurationForm', () => {
       ocr2ExecutePluginEnabled: false,
       ocr2MedianPluginEnabled: false,
       ocr2MercuryPluginEnabled: false,
+      ocr2ForwarderAddress: '',
     }
 
     render(

--- a/src/components/Form/ChainConfigurationForm.tsx
+++ b/src/components/Form/ChainConfigurationForm.tsx
@@ -23,25 +23,26 @@ import {
 import Typography from '@material-ui/core/Typography'
 
 export type FormValues = {
-  chainID: string
-  chainType: string
   accountAddr: string
   adminAddr: string
+  chainID: string
+  chainType: string
   fluxMonitorEnabled: boolean
   ocr1Enabled: boolean
   ocr1IsBootstrap: boolean
+  ocr1KeyBundleID?: string | null
   ocr1Multiaddr?: string | null
   ocr1P2PPeerID?: string | null
-  ocr1KeyBundleID?: string | null
-  ocr2Enabled: boolean
-  ocr2IsBootstrap: boolean
-  ocr2Multiaddr?: string | null
-  ocr2P2PPeerID?: string | null
-  ocr2KeyBundleID?: string | null
   ocr2CommitPluginEnabled: boolean
+  ocr2Enabled: boolean
   ocr2ExecutePluginEnabled: boolean
+  ocr2ForwarderAddress?: string | null
+  ocr2IsBootstrap: boolean
+  ocr2KeyBundleID?: string | null
   ocr2MedianPluginEnabled: boolean
   ocr2MercuryPluginEnabled: boolean
+  ocr2Multiaddr?: string | null
+  ocr2P2PPeerID?: string | null
 }
 
 const ValidationSchema = Yup.object().shape({
@@ -89,6 +90,7 @@ const ValidationSchema = Yup.object().shape({
   ocr2ExecutePluginEnabled: Yup.boolean().required('Required'),
   ocr2MedianPluginEnabled: Yup.boolean().required('Required'),
   ocr2MercuryPluginEnabled: Yup.boolean().required('Required'),
+  ocr2ForwarderAddress: Yup.string().nullable(),
 })
 
 const styles = (theme: Theme) => {
@@ -501,6 +503,21 @@ export const ChainConfigurationForm = withStyles(styles)(
                                   type="checkbox"
                                   Label={{
                                     label: 'Mercury',
+                                  }}
+                                />
+                              </Grid>
+
+                              <Grid item xs={12} md={12}>
+                                <Field
+                                  component={TextField}
+                                  id="ocr2ForwarderAddress"
+                                  name="ocr2ForwarderAddress"
+                                  label="Forwarder Address (optional)"
+                                  fullWidth
+                                  helperText="The forwarder address from the Operator Forwarder Contract"
+                                  FormHelperTextProps={{
+                                    'data-testid':
+                                      'ocr2ForwarderAddress-helper-text',
                                   }}
                                 />
                               </Grid>

--- a/src/hooks/queries/useFeedsManagersWithProposalsQuery.ts
+++ b/src/hooks/queries/useFeedsManagersWithProposalsQuery.ts
@@ -21,6 +21,7 @@ const FEEDS_MANAGER__CHAIN_CONFIG_FIELDS = gql`
       enabled
       isBootstrap
       multiaddr
+      forwarderAddress
       p2pPeerID
       keyBundleID
       plugins {

--- a/src/screens/FeedsManager/EditSupportedChainDialog.tsx
+++ b/src/screens/FeedsManager/EditSupportedChainDialog.tsx
@@ -75,6 +75,7 @@ export const EditSupportedChainDialog = ({
     ocr2ExecutePluginEnabled: cfg.ocr2JobConfig.plugins.execute,
     ocr2MedianPluginEnabled: cfg.ocr2JobConfig.plugins.median,
     ocr2MercuryPluginEnabled: cfg.ocr2JobConfig.plugins.mercury,
+    ocr2ForwarderAddress: cfg.ocr2JobConfig.forwarderAddress,
   }
 
   const chainIDs: string[] = chainData

--- a/src/screens/FeedsManager/NewSupportedChainDialog.tsx
+++ b/src/screens/FeedsManager/NewSupportedChainDialog.tsx
@@ -65,6 +65,7 @@ export const NewSupportedChainDialog = ({ onClose, open, onSubmit }: Props) => {
     ocr2ExecutePluginEnabled: false,
     ocr2MedianPluginEnabled: false,
     ocr2MercuryPluginEnabled: false,
+    ocr2ForwarderAddress: '',
   }
 
   const chainIDs: string[] = chainData

--- a/src/screens/FeedsManager/SupportedChainsCard.tsx
+++ b/src/screens/FeedsManager/SupportedChainsCard.tsx
@@ -336,6 +336,10 @@ export const SupportedChainsCard = withStyles(styles)(
               ocr2KeyBundleID:
                 values.ocr2KeyBundleID != '' ? values.ocr2KeyBundleID : null,
               ocr2Plugins: `{"commit":${values.ocr2CommitPluginEnabled},"execute":${values.ocr2ExecutePluginEnabled},"median":${values.ocr2MedianPluginEnabled},"mercury":${values.ocr2MercuryPluginEnabled}}`,
+              ocr2ForwarderAddress:
+                values.ocr2ForwarderAddress !== ''
+                  ? values.ocr2ForwarderAddress
+                  : null,
             },
           },
         })
@@ -408,6 +412,10 @@ export const SupportedChainsCard = withStyles(styles)(
               ocr2KeyBundleID:
                 values.ocr2KeyBundleID != '' ? values.ocr2KeyBundleID : null,
               ocr2Plugins: `{"commit":${values.ocr2CommitPluginEnabled},"execute":${values.ocr2ExecutePluginEnabled},"median":${values.ocr2MedianPluginEnabled},"mercury":${values.ocr2MercuryPluginEnabled}}`,
+              ocr2ForwarderAddress:
+                values.ocr2ForwarderAddress !== ''
+                  ? values.ocr2ForwarderAddress
+                  : null,
             },
           },
         })


### PR DESCRIPTION
## Description

Add support for setting operator forwarder address for OCR2 jobs managed by FMS

## Steps to Test

1. `yarn && yarn setup`
2. `yarn start`
3. ...etc

# Checklist

If this PR creates changes to the operator-ui itself, rather than tests, pipeline changes, etc. Then please create a changeset so that a new release is created, and the changelog is updated. See: https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md#what-is-a-changeset

- [x] This PR has an accompanying changeset if needed.
