### PR TITLE
BCF-2591-allow-simple-passwords: reverting notification

### DIFF
--- a/.changeset/shy-moose-walk.md
+++ b/.changeset/shy-moose-walk.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': patch
+---
+
+Removing notification for AllowSimplePasswords breaking change

--- a/src/screens/Configuration/ConfigurationV2Card/ConfigurationV2Card.tsx
+++ b/src/screens/Configuration/ConfigurationV2Card/ConfigurationV2Card.tsx
@@ -68,16 +68,6 @@ const TOMLPanel = ({ loading, toml, error = '', title, expanded }: Props) => {
   )
 }
 
-const AllowSimplePasswordsNotification = () => {
-  const allowSimplePasswordsNotification =
-    'Starting in 2.6.0, chainlink nodes will no longer AllowSimplePasswords=true for production builds. Any TOML configuration that sets the following line will fail validation checks in `node start` or `node validate`.'
-  return (
-    <Card>
-      <CardHeader title={<>{allowSimplePasswordsNotification}</>} />
-    </Card>
-  )
-}
-
 export const ConfigurationV2Card = () => {
   const { data, loading, error } = useQuery<
     FetchConfigV2,
@@ -92,7 +82,6 @@ export const ConfigurationV2Card = () => {
         <Grid item xs={12}>
           <Card>
             <CardHeader title="TOML Configuration" />
-            <AllowSimplePasswordsNotification />
             <TOMLPanel
               title="V2 config dump:"
               error={error?.message}
@@ -111,7 +100,6 @@ export const ConfigurationV2Card = () => {
       <Grid item xs={12}>
         <Card>
           <CardHeader title="TOML Configuration" />
-          <AllowSimplePasswordsNotification />
           <TOMLPanel
             title="User specified:"
             error={error?.message}


### PR DESCRIPTION
## Description

`<description>`

## Steps to Test

1. `yarn && yarn setup`
2. `yarn start`
3. ...etc

# Checklist

If this PR creates changes to the operator-ui itself, rather than tests, pipeline changes, etc. Then please create a changeset so that a new release is created, and the changelog is updated. See: https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md#what-is-a-changeset

- [x ] This PR has an accompanying changeset if needed.
