### PR TITLE
remove p2p v1 field p2pBootstrapPeers

### DIFF
--- a/.changeset/gold-poems-relax.md
+++ b/.changeset/gold-poems-relax.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': minor
+---
+
+remove p2p v1 field p2pBootstrapPeers

--- a/src/screens/Job/JobView.tsx
+++ b/src/screens/Job/JobView.tsx
@@ -54,7 +54,6 @@ const JOB_PAYLOAD__SPEC = gql`
       isBootstrapPeer
       keyBundleID
       observationTimeout
-      p2pBootstrapPeers
       p2pv2Bootstrappers
       transmitterAddress
     }

--- a/src/screens/Job/generateJobDefinition.test.ts
+++ b/src/screens/Job/generateJobDefinition.test.ts
@@ -214,9 +214,6 @@ observationSource = """
           '4ee612467c3caea7bdab57ab62937adfc4d195516c30139a737f85098b35d9af',
         isBootstrapPeer: false,
         observationTimeout: '10s',
-        p2pBootstrapPeers: [
-          '/ip4/139.59.41.32/tcp/12000/p2p/12D3KooWGKhStcrvCr5RBYKaSRNX4ojrxHcmpJuFmHWenT6aAQAY',
-        ],
         p2pv2Bootstrappers: [
           '12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw@localhost:5001',
         ],
@@ -247,9 +244,6 @@ evmChainID = "42"
 isBootstrapPeer = false
 keyBundleID = "4ee612467c3caea7bdab57ab62937adfc4d195516c30139a737f85098b35d9af"
 observationTimeout = "10s"
-p2pBootstrapPeers = [
-  "/ip4/139.59.41.32/tcp/12000/p2p/12D3KooWGKhStcrvCr5RBYKaSRNX4ojrxHcmpJuFmHWenT6aAQAY"
-]
 p2pv2Bootstrappers = [
   "12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw@localhost:5001"
 ]
@@ -287,9 +281,6 @@ observationSource = """
         keyBundleID:
           '4ee612467c3caea7bdab57ab62937adfc4d195516c30139a737f85098b35d9af',
         observationTimeout: '10s',
-        p2pBootstrapPeers: [
-          '/ip4/139.59.41.32/tcp/12000/p2p/12D3KooWGKhStcrvCr5RBYKaSRNX4ojrxHcmpJuFmHWenT6aAQAY',
-        ],
         p2pv2Bootstrappers: [
           '12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw@localhost:5001',
         ],
@@ -320,9 +311,6 @@ evmChainID = "42"
 isBootstrapPeer = true
 keyBundleID = "4ee612467c3caea7bdab57ab62937adfc4d195516c30139a737f85098b35d9af"
 observationTimeout = "10s"
-p2pBootstrapPeers = [
-  "/ip4/139.59.41.32/tcp/12000/p2p/12D3KooWGKhStcrvCr5RBYKaSRNX4ojrxHcmpJuFmHWenT6aAQAY"
-]
 p2pv2Bootstrappers = [
   "12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw@localhost:5001"
 ]

--- a/src/screens/Job/generateJobDefinition.ts
+++ b/src/screens/Job/generateJobDefinition.ts
@@ -124,7 +124,6 @@ export const generateJobDefinition = (
           'isBootstrapPeer',
           'keyBundleID',
           'observationTimeout',
-          'p2pBootstrapPeers',
           'p2pv2Bootstrappers',
           'transmitterAddress',
         ),


### PR DESCRIPTION
Remove the P2P V1 field `p2pBootstrapPeers`. 

Supports:
- https://github.com/smartcontractkit/chainlink/pull/10872