### PR TITLE
fix: changelog release entries

### DIFF
--- a/scripts/release.mts
+++ b/scripts/release.mts
@@ -9,11 +9,11 @@ const readChangesets =
   _readChangesets.default as typeof import('@changesets/read/dist/declarations/src/index.js')['default']
 
 // These paths are relative to the git root
-const ASSETS_DIR = './assets';
-const CHANGELOG_PATH = './CHANGELOG.md';
+const ASSETS_DIR = './assets'
+const CHANGELOG_PATH = './CHANGELOG.md'
 
 async function main() {
-  await setup();
+  await setup()
   await checkExternalScriptDependencies()
   await maybeConsumeVersions()
   const { gitTag, filename } = await pkgToTarball(ASSETS_DIR)
@@ -79,20 +79,30 @@ async function modifyChangelog(changelogPath: string, gitTag: string) {
   const version = `## ${gitTag.substring(1)}`
   const changelogHeaderVersionPattern = /^## [0-9]+.[0-9]+.[0-9]+-?[0-9a-z]*$/gm
 
-  const matchedVersions: { match: string, index: number }[]  = [...changelog.matchAll(changelogHeaderVersionPattern)].map((m) => {
-    return { match: m[0], index: m.index }
-  })
-  .filter((m): m is { match: string, index: number } => m.index !== undefined) // filter out undefined indexes
-  .sort((a, b) => a.index! - b.index!) // sort ascending by index (top to bottom)
+  const matchedVersions: { match: string; index: number }[] = [
+    ...changelog.matchAll(changelogHeaderVersionPattern),
+  ]
+    .map((m) => {
+      return { match: m[0], index: m.index }
+    })
+    .filter((m): m is { match: string; index: number } => m.index !== undefined) // filter out undefined indexes
+    .sort((a, b) => a.index! - b.index!) // sort ascending by index (top to bottom)
 
   if (matchedVersions.length === 0) {
     warn(`No versions found in changelog, skipping changelog modification.`)
     return
-  } else if (matchedVersions.length === 1 && matchedVersions[0].match === `${version}`) {
-    log(`Only changelog entry is for ${version}, skipping changelog modification.`)
+  } else if (
+    matchedVersions.length === 1 &&
+    matchedVersions[0].match === `${version}`
+  ) {
+    log(
+      `Only changelog entry is for ${version}, skipping changelog modification.`,
+    )
     return
   } else if (matchedVersions[0].match !== `${version}`) {
-    log(`First changelog version entry is ${matchedVersions[0].match} and not ${version}, skipping changelog modification.`)
+    log(
+      `First changelog version entry is ${matchedVersions[0].match} and not ${version}, skipping changelog modification.`,
+    )
     return
   }
 

--- a/scripts/release.mts
+++ b/scripts/release.mts
@@ -77,7 +77,7 @@ async function modifyChangelog(changelogPath: string, gitTag: string) {
 
   // git tag version to changelog version header format (v0.0.0-0 -> ## 0.0.0-0)
   const version = `## ${gitTag.substring(1)}`
-  const changelogHeaderVersionPattern = /^## [0-9]+.[0-9]+.[0-9]+-?[0-9a-z]*$/gm
+  const changelogHeaderVersionPattern = /^## [0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}(?:-[0-9a-z]{1,15})?$/gm
 
   const matchedVersions: { match: string; index: number }[] = [
     ...changelog.matchAll(changelogHeaderVersionPattern),

--- a/scripts/release.mts
+++ b/scripts/release.mts
@@ -77,7 +77,7 @@ async function modifyChangelog(changelogPath: string, gitTag: string) {
 
   // git tag version to changelog version header format (v0.0.0-0 -> ## 0.0.0-0)
   const version = `## ${gitTag.substring(1)}`
-  const changelogHeaderVersionPattern = /^## [0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}(?:-[0-9a-z]{1,15})?$/gm
+  const changelogHeaderVersionPattern = /^## [0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}(?:-[0-9a-z]{1,15}){0,1}$/gm
 
   const matchedVersions: { match: string; index: number }[] = [
     ...changelog.matchAll(changelogHeaderVersionPattern),

--- a/scripts/release.mts
+++ b/scripts/release.mts
@@ -8,26 +8,19 @@ import _readChangesets from '@changesets/read'
 const readChangesets =
   _readChangesets.default as typeof import('@changesets/read/dist/declarations/src/index.js')['default']
 
+// These paths are relative to the git root
+const ASSETS_DIR = './assets';
+const CHANGELOG_PATH = './CHANGELOG.md';
+
 async function main() {
-  if (!process.env.DEBUG) {
-    $.verbose = false
-  }
+  await setup();
   await checkExternalScriptDependencies()
-  await runAtGitRoot()
-  // These values are relative to the git root
-  const packDir = './assets'
-  const changelogPath = './CHANGELOG.md'
   await maybeConsumeVersions()
-
-  const { gitTag, filename } = await pkgToTarball(packDir)
-
-  if (await checkIfReleaseExists(gitTag)) {
-    warn(`Release under tag "${gitTag}" already exists, skipping...`)
-    return
-  }
-
-  await createGithubRelease(packDir, filename, gitTag, changelogPath)
+  const { gitTag, filename } = await pkgToTarball(ASSETS_DIR)
+  await modifyChangelog(CHANGELOG_PATH, gitTag)
+  await createGithubRelease(ASSETS_DIR, filename, gitTag, CHANGELOG_PATH)
 }
+
 main()
 
 interface NpmPack {
@@ -42,22 +35,80 @@ interface NpmPack {
   files: { path: string; size: number; mode: number }[]
 }
 
+/**
+ * Creates a Github release through the Github CLI, if the release doesn't already exist.
+ * @param packDir The directory where the tarball is located
+ * @param filename The filename of the tarball
+ * @param gitTag The git tag to create the release under
+ * @param changelogPath The path to the changelog
+ */
 async function createGithubRelease(
   packDir: string,
   filename: string,
   gitTag: string,
   changelogPath: string,
 ) {
+  if (await checkIfReleaseExists(gitTag)) {
+    warn(`Release under tag "${gitTag}" already exists, skipping...`)
+    return
+  }
+
   const asset = `${packDir}/${filename}`
   log(
     `Creating release with tag "${gitTag}" with asset "${asset}" and changelog of ${changelogPath}`,
   )
   await $`gh release create ${gitTag} ${packDir}/${filename} -F ${changelogPath}`
+
   log(`Cleaning up...`)
   log(`Removing ${packDir}`)
   fs.remove(packDir)
 }
 
+/**
+ * Modifies the CHANGELOG.md to exclude older version notes so they're not included in the release.
+ * This code is dependent on how the changelog is formatted, and will no-op if the changelog doesn't
+ * match the expected format.
+ * @param changelogPath The path to the changelog
+ * @param gitTag The git tag to include changes for
+ */
+async function modifyChangelog(changelogPath: string, gitTag: string) {
+  log(`Modifying changelog to only include changes for ${gitTag}...`)
+  const changelog = await fs.readFile(changelogPath, 'utf-8')
+
+  // git tag version to changelog version header format (v0.0.0-0 -> ## 0.0.0-0)
+  const version = `## ${gitTag.substring(1)}`
+  const changelogHeaderVersionPattern = /^## [0-9]+.[0-9]+.[0-9]+-?[0-9a-z]*$/gm
+
+  const matchedVersions: { match: string, index: number }[]  = [...changelog.matchAll(changelogHeaderVersionPattern)].map((m) => {
+    return { match: m[0], index: m.index }
+  })
+  .filter((m): m is { match: string, index: number } => m.index !== undefined) // filter out undefined indexes
+  .sort((a, b) => a.index! - b.index!) // sort ascending by index (top to bottom)
+
+  if (matchedVersions.length === 0) {
+    warn(`No versions found in changelog, skipping changelog modification.`)
+    return
+  } else if (matchedVersions.length === 1 && matchedVersions[0].match === `${version}`) {
+    log(`Only changelog entry is for ${version}, skipping changelog modification.`)
+    return
+  } else if (matchedVersions[0].match !== `${version}`) {
+    log(`First changelog version entry is ${matchedVersions[0].match} and not ${version}, skipping changelog modification.`)
+    return
+  }
+
+  // First index is now guaranteed to be the one matching the git tag
+  // Second index is the next version entry as we sorted the array by index
+  const secondVersionMatch = matchedVersions[1]
+
+  // trim the changelog to the second version match
+  const trimmedChangelog = changelog.substring(0, secondVersionMatch.index)
+  await fs.writeFile(changelogPath, trimmedChangelog)
+}
+
+/**
+ * If there are changesets (changeset files in .changeset directory), consume them and create a snapshot release.
+ * Otherwise, that means the changesets PR was merged and we can create a release full release.
+ */
 async function maybeConsumeVersions() {
   const hasChanges = await readChangesets('.').then((sets) => sets.length > 0)
   if (!hasChanges) {
@@ -67,22 +118,6 @@ async function maybeConsumeVersions() {
 
   log(`Attempting to create snapshot release...`)
   await $`yarn changeset version --snapshot`
-}
-
-async function runAtGitRoot() {
-  const gitRoot = await $`git rev-parse --show-toplevel`
-  cd(gitRoot.stdout.trimEnd())
-}
-
-async function checkExternalScriptDependencies() {
-  try {
-    await which('gh')
-  } catch {
-    error(
-      `This script requires "gh" to be installed, see: https://github.com/cli/cli/releases`,
-    )
-    process.exit(1)
-  }
 }
 
 async function checkIfReleaseExists(gitTag: string): Promise<boolean> {
@@ -112,11 +147,44 @@ async function pkgToTarball(packDir: string) {
 }
 
 /**
- * Helper functions
+ * Setup the script by changing the working directory to the git root and setting zx verbosity.
  */
+async function setup() {
+  // Set zx verbosity based on DEBUG env var
+  if (!process.env.DEBUG) {
+    $.verbose = false
+  }
+
+  await runAtGitRoot()
+}
+
+/**
+ * Change the working directory to the git root.
+ */
+async function runAtGitRoot() {
+  const gitRoot = await $`git rev-parse --show-toplevel`
+  cd(gitRoot.stdout.trimEnd())
+}
+
+/**
+ * Check that external dependencies are installed.
+ * Currently only checks for "gh" (Github CLI).
+ */
+async function checkExternalScriptDependencies() {
+  try {
+    await which('gh')
+  } catch {
+    error(
+      `This script requires "gh" to be installed, see: https://github.com/cli/cli/releases`,
+    )
+    process.exit(1)
+  }
+}
+
 function log(...params: Parameters<typeof chalk['gray']>): void {
   console.log(chalk.gray(...params))
 }
+
 function debug(...params: Parameters<typeof chalk['blue']>): void {
   if (process.env.DEBUG) {
     console.debug(chalk.blue('DEBUG:'), chalk.blue(...params))

--- a/scripts/release.mts
+++ b/scripts/release.mts
@@ -77,7 +77,8 @@ async function modifyChangelog(changelogPath: string, gitTag: string) {
 
   // git tag version to changelog version header format (v0.0.0-0 -> ## 0.0.0-0)
   const version = `## ${gitTag.substring(1)}`
-  const changelogHeaderVersionPattern = /^## [0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}(?:-[0-9a-z]{1,15}){0,1}$/gm
+  const changelogHeaderVersionPattern =
+    /^## [0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}(?:-[0-9a-z]{1,15}){0,1}$/gm
 
   const matchedVersions: { match: string; index: number }[] = [
     ...changelog.matchAll(changelogHeaderVersionPattern),
@@ -104,15 +105,15 @@ async function modifyChangelog(changelogPath: string, gitTag: string) {
       `First changelog version entry is ${matchedVersions[0].match} and not ${version}, skipping changelog modification.`,
     )
     return
+  } else {
+    // First index is now guaranteed to be the one matching the git tag
+    // Second index is the next version entry as we sorted the array by index
+    const secondVersionMatch = matchedVersions[1]
+
+    // trim the changelog to the second version match
+    const trimmedChangelog = changelog.substring(0, secondVersionMatch.index)
+    await fs.writeFile(changelogPath, trimmedChangelog)
   }
-
-  // First index is now guaranteed to be the one matching the git tag
-  // Second index is the next version entry as we sorted the array by index
-  const secondVersionMatch = matchedVersions[1]
-
-  // trim the changelog to the second version match
-  const trimmedChangelog = changelog.substring(0, secondVersionMatch.index)
-  await fs.writeFile(changelogPath, trimmedChangelog)
 }
 
 /**

--- a/scripts/release.mts
+++ b/scripts/release.mts
@@ -77,6 +77,7 @@ async function modifyChangelog(changelogPath: string, gitTag: string) {
 
   // git tag version to changelog version header format (v0.0.0-0 -> ## 0.0.0-0)
   const version = `## ${gitTag.substring(1)}`
+  // Pattern for "## x.y.z" with an optional snapshot release suffix (-abc123)
   const changelogHeaderVersionPattern =
     /^## [0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}(?:-[0-9a-z]{1,15}){0,1}$/gm
 


### PR DESCRIPTION
## Description

Modifying the `release.mts` script to exclude previous releases changelog entries.

## Steps to Test

1. Add `--draft` to `scripts/release.mts` to ensure you don't create a github release
```
await $`gh release create --draft ...`
```
2.  While in `scripts` directory - `yarn release`

<details><summary>Changelog Diff From Testing</summary>
<p>

```
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 319620a..24c18ba 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,51 @@
 # @smartcontractkit/operator-ui
 
-## 0.7.0
+## 0.8.0-0953c48
 
 ### Minor Changes
 
-- d5517c9: Swap out compiler for testing and building for swc
+- 53c5f87: rename fromAddress to fromAddresses in blockhashStoreSpec
+- b286a55: Remove the `maxGasPriceGWei` field from VRF job details page.
+- 374e9b4: Displays feed ID on OCR2 JobSpec
+- 3c7a06f: Add ability to show TOML config
+
+  On the configuration screen, the user is now able to view their node's TOML config
+
+- 11e96a8: remove p2p v1 field p2pBootstrapPeers
+- 06f745d: Update the VRF job spec UI to include vrfOwnerAddress; Update the BHS job spec UI to include coordinatorV2PlusAddress, trustedBlockhashStoreAddress and trustedBlockhashStoreBatchSize
+- 9f9c8db: Change the Account Balance section to accommodate multiple accounts on different chains.
+- 55a9fe7: add new job type: BlockHeaderFeeder
+- ec48501: New job type - Gateway
+- db6e6b4: Replaced "ETH balance" with "Native token balance"
+- 935a76a: Display the Feeds Manager navigation in the mobile navigation drawer
+- e658456: Adding notification for upcoming AllowSimplePasswords configuration breaking change in core v2.6.0
+- 2c669a2: Add OCR2 Key bundle creation
+- e0e85f9: Add order field in the `Nodes` screen
+- 67c1a28: Added support for the display and deletion of OCR version 2 (OCR2) keys
+
+### Patch Changes
+
+- 197331a: - Replaced rendering library to fix a bug that crashed the UI when task list contained two nodes in a loop
+  - Change Pending, Success and Error svg borders
+  - Task list tooltips are not positioned so that they don't go off-screen
+  - Added zoom and pan functionality to Task List
+- 21b9c41: Add more options to the OCR2 plugin selection for FMS
+- 2ab39ec: Show node type
+- a699501: Add deprecation warning for TelemetryIngress.URL and TelemetryIngress.ServerPubKey
+- f537fba: Fixes task run status display for unfinished tasks
+- ffd9ff4: Display the name of job proposals in Feeds Manager
+- 44bb788: Remove legacy config chain & node mutations.
+- 91e5ba4: Change the job creation error to specify that a job was created but it cannot start.
+- a03e68e: Fixed a bug that caused RPC nodes to not be listed under Chains -> Nodes
+- 43931df: Add OCR2 plugins selection for FMS
+- 93aee13: Fixes Node and Chain GQL queries which call the `CreatedAt` field which was removed
+- 461c900: Add deprecation warning for P2P.V1
+- 4480f1f: Add support for using operator forwarder in OCR2 jobs managed by FMS
+- f8e796f: Add revoked jobs tab in feeds manager
+- d41b999: Removing notification for AllowSimplePasswords breaking change
+- 69b88a0: Fixes infinite loop issue on Sign Out
+- 6917e8a: Fixed a bug where the Task List would not be displayed correctly if a run was successfully completed.
+- 059b169: Fix bug preventing selection of "Rows per page" in jobs/ID/runs page
+- c91c2a5: Allow job deletion requests to be sent from FMS
+- ba8eb05: dynamic config for legacy vs. TOML; syntax highlighting; expansion panels
 
-  Using swc leads to significant performance gains in both CI and CD, with a 60% reduction in webpack build times, and a 25% reduction in test times.
-
-  - Update to latest tsc version
-  - Use swc for jest tests instead of ts-jest
-  - Use swc for webpack builds
-  - Update jest dependencies
-  - Update jest snapshots based on JSON parsing changes in jsdom upgrade
-  - Update gitignore to exclude yarn error logs
-  - Fix serve config
-  - Remove unused autobind decorator
-
-- c6c81c1: Add "Key Admin Override" modal
-
-  The `/keys` page in Operator UI now exposes several admin commands, namely:
-
-  - An "abandon" checkbox to abandon all current transactions
-  - Enable/disable a key for a given chain
-  - Manually set the nonce for a key.
-
-  See [this PR](https://github.com/smartcontractkit/chainlink/pull/7406) for a screenshot example.
-
-- 1ab4990: Fetch chainlink node build info during runtime
-
-  Previously, the chainlink version and commit sha were baked into the static assets. Now, they're fetched during runtime via the `/v2/build_info` endpoint after the user has logged in. This enables the operator ui build phase to be isolated from the chainlink build phase, as we no longer need to know the version and commit sha of the chainlink node ahead of time.
```

</p>
</details> 

# Checklist

If this PR creates changes to the operator-ui itself, rather than tests, pipeline changes, etc. Then please create a changeset so that a new release is created, and the changelog is updated. See: https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md#what-is-a-changeset

- [x] This PR has an accompanying changeset if needed.

---

Related to: https://github.com/smartcontractkit/github-app-token-issuer/pull/65

[RE-2040](https://smartcontract-it.atlassian.net/browse/RE-2040)