### PR TITLE
feat: use changesets-signed-commits

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upsert Release Pull Request
         id: changesets
-        uses: changesets/action@v1
+        uses: smartcontractkit/.github/actions/signed-commits@95b6030f4d23d5d87f53eb0f018f51806afa4da3 # changesets-signed-commits@1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description

Updating to use in-house [`changesets-signed-commits`](https://github.com/smartcontractkit/.github/releases/tag/changesets-signed-commits%401.0.1) rather than the official `changesets/action` github action which doesn't support commit signing.


## Steps to Test

N/A - this change only effects CI/CD workflows

# Checklist

- [x] This PR has an accompanying changeset if needed.

---

https://smartcontract-it.atlassian.net/browse/RE-2179
