### PR TITLE
add tag input to chainlink-ci workflow

### DIFF
--- a/.changeset/purple-humans-explain.md
+++ b/.changeset/purple-humans-explain.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': patch
+---
+
+Fix chainlink-ci workflow by adding tag input to checkout specific tag/commit for operator-ui repo

--- a/.github/workflows/chainlink-ci.yml
+++ b/.github/workflows/chainlink-ci.yml
@@ -16,6 +16,9 @@ on:
       ref:
         required: true
         description: The chainlink ref to test against
+      tag:
+        required: true
+        description: The operator-ui tag/commit to checkout against
 
 jobs:
   detect-gql-breaking-changes:
@@ -34,6 +37,8 @@ jobs:
 
       - name: Checkout the repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ inputs.tag }}
 
       - name: Setup node
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1


### PR DESCRIPTION
## Description

This adds a new `tag` input to chainlink-ci workflow to fix a bug that only checks out the latest commit of this repo when being trigger by chainlink.

## Steps to Test

1. `yarn && yarn setup`
2. `yarn start`
3. ...etc

# Checklist

If this PR creates changes to the operator-ui itself, rather than tests, pipeline changes, etc. Then please create a changeset so that a new release is created, and the changelog is updated. See: https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md#what-is-a-changeset

- [x] This PR has an accompanying changeset if needed.
