### PR TITLE
[KS-135] Add workflow spec job type

### DIFF
--- a/.changeset/brown-rivers-accept.md
+++ b/.changeset/brown-rivers-accept.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': minor
+---
+
+Add support for Workflow Spec job types

--- a/src/screens/Job/JobView.tsx
+++ b/src/screens/Job/JobView.tsx
@@ -133,6 +133,11 @@ const JOB_PAYLOAD__SPEC = gql`
       gatewayConfig
       createdAt
     }
+    ... on WorkflowSpec {
+      workflowID
+      workflowOwner
+      workflow
+    }
   }
 `
 

--- a/src/screens/Job/generateJobDefinition.test.ts
+++ b/src/screens/Job/generateJobDefinition.test.ts
@@ -629,4 +629,34 @@ Port = 8_080
     const output = generateJobDefinition(job)
     expect(output.definition).toEqual(expectedOutput)
   })
+
+  it('generates a valid Workflow definition', () => {
+    const job: JobPayload_Fields = {
+      id: '1',
+      type: 'workflow',
+      schemaVersion: 1,
+      name: 'workflow test',
+      externalJobID: '00000000-0000-0000-0000-0000000000001',
+      maxTaskDuration: '10s',
+      spec: {
+        __typename: 'WorkflowSpec',
+        workflowID: '<workflow id>',
+        workflow: '<workflow spec>',
+        workflowOwner: '<workflow owner>',
+      },
+      observationSource: '',
+      ...otherJobFields,
+    }
+
+    const expectedOutput = `type = "workflow"
+schemaVersion = 1
+name = "workflow test"
+externalJobID = "00000000-0000-0000-0000-0000000000001"
+workflowID = "<workflow id>"
+workflow = "<workflow spec>"
+workflowOwner = "<workflow owner>"
+`
+    const output = generateJobDefinition(job)
+    expect(output.definition).toEqual(expectedOutput)
+  })
 })

--- a/src/screens/Job/generateJobDefinition.ts
+++ b/src/screens/Job/generateJobDefinition.ts
@@ -252,6 +252,19 @@ export const generateJobDefinition = (
       }
 
       break
+
+    case 'WorkflowSpec':
+      values = {
+        ...extractJobFields(job),
+        ...extractSpecFields(
+          job.spec,
+          'workflowID',
+          'workflow',
+          'workflowOwner',
+        ),
+      }
+
+      break
     default:
       return { definition: '' }
     case 'WebhookSpec':


### PR DESCRIPTION
## Description

Add support for workflow spec job types.

## Steps to Test

1. `yarn && yarn setup`
2. `yarn start`
3. ...etc

# Checklist

If this PR creates changes to the operator-ui itself, rather than tests, pipeline changes, etc. Then please create a changeset so that a new release is created, and the changelog is updated. See: https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md#what-is-a-changeset

- [x] This PR has an accompanying changeset if needed.
