### PR TITLE
remove chaintype filter on bundleid

### DIFF
--- a/.changeset/dirty-planes-promise.md
+++ b/.changeset/dirty-planes-promise.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': patch
+---
+
+remove filter for chaintype for bundleids in feeds manager

--- a/src/components/Form/ChainConfigurationForm.tsx
+++ b/src/components/Form/ChainConfigurationForm.tsx
@@ -516,16 +516,11 @@ export const ChainConfigurationForm = withStyles(styles)(
                                       'ocr2KeyBundleID-helper-text',
                                   }}
                                 >
-                                  {ocr2Keys
-                                    .filter(
-                                      (key) =>
-                                        values.chainType === key.chainType,
-                                    )
-                                    .map((key) => (
-                                      <MenuItem key={key.id} value={key.id}>
-                                        {key.id}
-                                      </MenuItem>
-                                    ))}
+                                  {ocr2Keys.map((key) => (
+                                    <MenuItem key={key.id} value={key.id}>
+                                      {key.id}
+                                    </MenuItem>
+                                  ))}
                                 </Field>
                               </Grid>
 


### PR DESCRIPTION
## Description
Remove the chainType filter for feeds manager until we can return chain type in the chain resolver

- [ ] This PR has an accompanying changeset if needed.
