### PR TITLE
Add button to drop 'unstarted' txs

### DIFF
--- a/.changeset/pretty-gifts-complain.md
+++ b/.changeset/pretty-gifts-complain.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': minor
+---
+
+add button to drop 'unstarted' txs

--- a/@types/core/store/models.d.ts
+++ b/@types/core/store/models.d.ts
@@ -62,6 +62,8 @@ declare module 'core/store/models' {
     nextNonce: ?integer
     abandon: ?boolean
     enabled: ?boolean
+    abandonUnstarted: ?boolean
+    subject: ?string
   }
 
   export interface BuildInfo {

--- a/src/api/v2/evmKeys.ts
+++ b/src/api/v2/evmKeys.ts
@@ -22,6 +22,13 @@ export class EVMKeys {
     if (request.enabled !== null) {
       query.append('enabled', String(request.enabled))
     }
+    if (request.abandonUnstarted !== null) {
+      query.append('abandonUnstarted', String(request.abandonUnstarted))
+      
+      if (request.subject !== null) {
+        query.append('subject', request.subject)
+      }
+    }
 
     const endpoint = ENDPOINT + '?' + query.toString()
 

--- a/src/screens/KeyManagement/EVMAccountRow.tsx
+++ b/src/screens/KeyManagement/EVMAccountRow.tsx
@@ -84,6 +84,12 @@ const styles = (theme: Theme) =>
     runJobModalContent: {
       overflow: 'hidden',
     },
+    // Adjusts the text field to fit within the modal padding
+    textField: {
+      marginLeft: theme.spacing.unit * 6,
+      marginRight: theme.spacing.unit * 6,
+      width: 'calc(100% - 96px)', 
+    },
   })
 
 interface Props {
@@ -293,7 +299,7 @@ const UnstyledEVMAccountRow: React.FC<Props> = ({
                 {abandonUnstarted && (
                   <FormGroup>
                     <TextField
-                      className={classes.infoText}
+                      className={classes.textField}
                       name="subjectField"
                       type="text"
                       label="Subject (optional)"

--- a/src/screens/KeyManagement/EVMAccountRow.tsx
+++ b/src/screens/KeyManagement/EVMAccountRow.tsx
@@ -50,8 +50,8 @@ const styles = (theme: Theme) =>
       lineHeight: '1rem',
     },
     dialogPaper: {
-      minHeight: '360px',
-      maxHeight: '360px',
+      minHeight: '450px',
+      maxHeight: '450px',
       minWidth: '670px',
       maxWidth: '670px',
       overflow: 'hidden',
@@ -98,12 +98,16 @@ function apiCall({
   nextNonce,
   abandon,
   enabled,
+  abandonUnstarted,
+  subject
 }: {
   evmChainID: string
   address: string
   nextNonce: bigint | null
   abandon: boolean
   enabled: boolean
+  abandonUnstarted: boolean
+  subject: string
 }): Promise<ApiResponse<EVMKey>> {
   const definition: EVMKeysChainRequest = {
     evmChainID,
@@ -111,6 +115,8 @@ function apiCall({
     nextNonce,
     abandon,
     enabled,
+    abandonUnstarted,
+    subject,
   }
   return api.v2.evmKeys.chain(definition)
 }
@@ -128,10 +134,12 @@ const UnstyledEVMAccountRow: React.FC<Props> = ({
   const [enabled, setEnabled] = useState(!ethKey.isDisabled)
   const [nextNonce, setNextNonce] = useState<bigint | null>(null)
   const [abandon, setAbandon] = useState(false)
+  const [abandonUnstarted, setAbandonUnstarted] = useState(false)
+  const [subject, setSubject] = useState('')
 
   const onSubmit = (event: React.SyntheticEvent) => {
     event.preventDefault()
-    handleUpdate(nextNonce, abandon, enabled)
+    handleUpdate(nextNonce, abandon, enabled, abandonUnstarted, subject)
   }
 
   const handleEnabledCheckboxChange = () => {
@@ -146,18 +154,30 @@ const UnstyledEVMAccountRow: React.FC<Props> = ({
     setAbandon(!abandon)
   }
 
+  const handleAbandonUnstartedCheckboxChange = () => {
+    setAbandonUnstarted(!abandonUnstarted)
+  }
+
+  const handleSubjectFieldChange = (event: any) => {
+    setSubject(event.target.value)
+  }
+
   const closeModal = () => {
     setModalOpen(false)
     // reset state
     setAbandon(false)
     setNextNonce(null)
     setEnabled(!ethKey.isDisabled)
+    setAbandonUnstarted(false)
+    setSubject('')
   }
 
   async function handleUpdate(
     nextNonce: bigint | null,
     abandon: boolean,
     enabled: boolean,
+    abandonUnstarted: boolean,
+    subject: string,
   ) {
     apiCall({
       evmChainID: ethKey.chain.id,
@@ -165,6 +185,8 @@ const UnstyledEVMAccountRow: React.FC<Props> = ({
       nextNonce,
       abandon,
       enabled,
+      abandonUnstarted,
+      subject,
     })
       .then(({ data }) => {
         refetch && refetch()
@@ -254,6 +276,32 @@ const UnstyledEVMAccountRow: React.FC<Props> = ({
                     label="Abandon all current transactions (use with caution!)"
                   />
                 </FormGroup>
+                <FormGroup>
+                  <FormControlLabel
+                    className={classes.infoText}
+                    color="secondary"
+                    control={
+                      <Checkbox
+                        name="abandonUnstartedCheckbox"
+                        checked={abandonUnstarted}
+                        onChange={handleAbandonUnstartedCheckboxChange}
+                      />
+                    }
+                    label="Abandon unstarted transactions"
+                  />
+                </FormGroup>
+                {abandonUnstarted && (
+                  <FormGroup>
+                    <TextField
+                      className={classes.infoText}
+                      name="subjectField"
+                      type="text"
+                      label="Subject (optional)"
+                      value={subject}
+                      onChange={handleSubjectFieldChange}
+                    />
+                  </FormGroup>
+                )}
                 <Grid
                   container
                   spacing={0}


### PR DESCRIPTION
## Description

Under Settings > Key Managment > EVM Chain Accounts > Admin, [we already have a button](https://github.com/smartcontractkit/operator-ui/blob/main/src/screens/KeyManagement/EVMAccountRow.tsx#L254) to “abandon all current transactions”. 

When clicked, this button hits the /v2/keys/evm/chain [endpoint](https://github.com/smartcontractkit/chainlink/blob/develop/core/web/router.go#L323). It will call the [Reset](https://github.com/smartcontractkit/chainlink/blob/develop/common/txmgr/txmgr.go#L228) method which ends up calling [TxStore Abandon](https://github.com/smartcontractkit/chainlink/blob/develop/common/txmgr/txmgr.go#L252) method. If we take a look at the [EVM implementation](https://github.com/smartcontractkit/chainlink/blob/develop/core/chains/evm/txmgr/evm_tx_store.go#L1942), we can see that this button `UPDATES evm.txes` table to set as abandoned all transactions that are` IN ('unconfirmed', 'in_progress', 'unstarted')` states for given `evm_chain_id` and `from_address`. 

Despite some similarities, we need something different.

Through this PR we are adding a new button that optionally receives a `subject` as a text field and only drops the `'unstarted'` txs. The key differences are that:

- We want to `DELETE` rather than `UPDATE` txs to `'abandoned'`.
- We are only interested in `'unstarted'` txs and not ` 'unconfirmed' `or `'in_progress'` ones.
- We want an additional text field to optionally send a `subject` to the API.

## Resources
- Placeholder for the upcoming txmgr PR, actively being worked by Narcis. 
- [BCI-2563](https://smartcontract-it.atlassian.net/browse/BCI-2563)

## Steps to Test

1. `yarn && yarn setup`
2. `yarn start`
3. ...etc

# Checklist

If this PR creates changes to the operator-ui itself, rather than tests, pipeline changes, etc. Then please create a changeset so that a new release is created, and the changelog is updated. See: https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md#what-is-a-changeset

- [x] This PR has an accompanying changeset if needed.
