### PR TITLE
[OPCORE-891] fix: Rename Feeds Manager -> Job Distributors 

### DIFF
--- a/.changeset/modern-balloons-sneeze.md
+++ b/.changeset/modern-balloons-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': minor
+---
+
+Rename Feeds Manager to Job Distributor

--- a/src/Private.tsx
+++ b/src/Private.tsx
@@ -74,7 +74,7 @@ const Private = ({ classes }: { classes: { content: string } }) => {
                 <ConfigPage />
               </PrivateRoute>
 
-              <PrivateRoute path="/feeds_manager">
+              <PrivateRoute path="/job_distributors">
                 <FeedsManagerPage />
               </PrivateRoute>
 

--- a/src/components/Form/FeedsManagerForm.tsx
+++ b/src/components/Form/FeedsManagerForm.tsx
@@ -61,7 +61,7 @@ export const FeedsManagerForm: React.FC<Props> = ({
                 label="URI"
                 required
                 fullWidth
-                helperText="Provided by the Feeds Manager operator"
+                helperText="Provided by the Job Distributor operator"
                 FormHelperTextProps={{ 'data-testid': 'uri-helper-text' }}
               />
             </Grid>
@@ -74,7 +74,7 @@ export const FeedsManagerForm: React.FC<Props> = ({
                 label="Public Key"
                 required
                 fullWidth
-                helperText="Provided by the Feeds Manager operator"
+                helperText="Provided by the Job Distributor operator"
                 FormHelperTextProps={{ 'data-testid': 'publicKey-helper-text' }}
               />
             </Grid>

--- a/src/pages/Header.tsx
+++ b/src/pages/Header.tsx
@@ -108,8 +108,8 @@ const Drawer = withStyles(drawerStyles)(
               <ListItem
                 button
                 component={() => (
-                  <BaseLink href={'/feeds_manager'}>
-                    <ListItemText primary="Job Distributor" />
+                  <BaseLink href={'/job_distributors'}>
+                    <ListItemText primary="Job Distributors" />
                   </BaseLink>
                 )}
                 className={classes.menuitem}
@@ -190,10 +190,11 @@ const Nav = withStyles(navStyles)(
           {isFeedsManagerFeatureEnabled && (
             <ListItem className={classes.horizontalNavItem}>
               <BaseLink
-                href={'/feeds_manager'}
+                href={'/job_distributors'}
                 className={classNames(
                   classes.horizontalNavLink,
-                  pathname.includes('/feeds_manager') && classes.activeNavLink,
+                  pathname.includes('/job_distributors') &&
+                    classes.activeNavLink,
                 )}
               >
                 Job Distributors

--- a/src/pages/Header.tsx
+++ b/src/pages/Header.tsx
@@ -109,7 +109,7 @@ const Drawer = withStyles(drawerStyles)(
                 button
                 component={() => (
                   <BaseLink href={'/feeds_manager'}>
-                    <ListItemText primary="Feeds Manager" />
+                    <ListItemText primary="Job Distributor" />
                   </BaseLink>
                 )}
                 className={classes.menuitem}
@@ -196,7 +196,7 @@ const Nav = withStyles(navStyles)(
                   pathname.includes('/feeds_manager') && classes.activeNavLink,
                 )}
               >
-                Feeds Manager
+                Job Distributors
               </BaseLink>
             </ListItem>
           )}

--- a/src/screens/Bridges/BridgesScreen.test.tsx
+++ b/src/screens/Bridges/BridgesScreen.test.tsx
@@ -21,7 +21,7 @@ function renderComponent(mocks: MockedResponse[]) {
         </MockedProvider>
       </Route>
 
-      <Route path="/feeds_manager/new">Redirect Success</Route>
+      <Route path="/job_distributors/new">Redirect Success</Route>
     </>,
     { initialEntries: ['/bridges?per=2'] },
   )

--- a/src/screens/EditFeedsManager/EditFeedsManagerScreen.test.tsx
+++ b/src/screens/EditFeedsManager/EditFeedsManagerScreen.test.tsx
@@ -61,7 +61,7 @@ describe('EditFeedsManagerScreen', () => {
 
     await waitForElementToBeRemoved(() => queryByRole('progressbar'))
 
-    expect(await findByText('Edit Feeds Manager')).toBeInTheDocument()
+    expect(await findByText('Edit Job Distributor')).toBeInTheDocument()
     expect(await findByTestId('feeds-manager-form')).toBeInTheDocument()
   })
 
@@ -167,7 +167,7 @@ describe('EditFeedsManagerScreen', () => {
 
     userEvent.click(getByRole('button', { name: /submit/i }))
 
-    expect(await findByText('Feeds Manager Updated')).toBeInTheDocument()
+    expect(await findByText('Job Distributor Updated')).toBeInTheDocument()
     expect(await findByText('Root Redirect Success')).toBeInTheDocument()
   })
 

--- a/src/screens/EditFeedsManager/EditFeedsManagerScreen.test.tsx
+++ b/src/screens/EditFeedsManager/EditFeedsManagerScreen.test.tsx
@@ -30,10 +30,10 @@ function renderComponent(mocks: MockedResponse[]) {
         </MockedProvider>
       </Route>
 
-      <Route exact path="/feeds_manager/new">
+      <Route exact path="/job_distributors/new">
         New Redirect Success
       </Route>
-      <Route exact path="/feeds_manager">
+      <Route exact path="/job_distributors">
         Root Redirect Success
       </Route>
     </>,

--- a/src/screens/EditFeedsManager/EditFeedsManagerScreen.tsx
+++ b/src/screens/EditFeedsManager/EditFeedsManagerScreen.tsx
@@ -77,7 +77,7 @@ export const EditFeedsManagerScreen: React.FC = () => {
     return (
       <Redirect
         to={{
-          pathname: '/feeds_manager/new',
+          pathname: '/job_distributors/new',
           state: { from: location },
         }}
       />
@@ -96,7 +96,7 @@ export const EditFeedsManagerScreen: React.FC = () => {
       const payload = result.data?.updateFeedsManager
       switch (payload?.__typename) {
         case 'UpdateFeedsManagerSuccess':
-          history.push('/feeds_manager')
+          history.push('/job_distributors')
 
           dispatch(notifySuccessMsg('Job Distributor Updated'))
 

--- a/src/screens/EditFeedsManager/EditFeedsManagerScreen.tsx
+++ b/src/screens/EditFeedsManager/EditFeedsManagerScreen.tsx
@@ -98,7 +98,7 @@ export const EditFeedsManagerScreen: React.FC = () => {
         case 'UpdateFeedsManagerSuccess':
           history.push('/feeds_manager')
 
-          dispatch(notifySuccessMsg('Feeds Manager Updated'))
+          dispatch(notifySuccessMsg('Job Distributor Updated'))
 
           break
         case 'NotFoundError':

--- a/src/screens/EditFeedsManager/EditFeedsManagerView.test.tsx
+++ b/src/screens/EditFeedsManager/EditFeedsManagerView.test.tsx
@@ -13,7 +13,7 @@ describe('EditFeedsManagerView', () => {
 
     render(<EditFeedsManagerView data={manager} onSubmit={handleSubmit} />)
 
-    expect(getByText('Edit Feeds Manager')).toBeInTheDocument()
+    expect(getByText('Edit Job Distributor')).toBeInTheDocument()
     expect(getByTestId('feeds-manager-form')).toHaveFormValues({
       name: 'Chainlink Feeds Manager',
       uri: manager.uri,

--- a/src/screens/EditFeedsManager/EditFeedsManagerView.tsx
+++ b/src/screens/EditFeedsManager/EditFeedsManagerView.tsx
@@ -25,7 +25,7 @@ export const EditFeedsManagerView: React.FC<Props> = ({ data, onSubmit }) => {
     <Grid container>
       <Grid item xs={12} md={11} lg={9}>
         <Card>
-          <CardHeader title="Edit Feeds Manager" />
+          <CardHeader title="Edit Job Distributor" />
           <CardContent>
             <FeedsManagerForm
               initialValues={initialValues}

--- a/src/screens/FeedsManager/FeedsManagerCard.test.tsx
+++ b/src/screens/FeedsManager/FeedsManagerCard.test.tsx
@@ -16,7 +16,7 @@ function renderComponent(manager: FeedsManagerFields) {
       <Route path="/">
         <FeedsManagerCard manager={manager} />
       </Route>
-      <Route path="/feeds_manager/edit">Redirect Success</Route>
+      <Route path="/job_distributors/edit">Redirect Success</Route>
     </>,
   )
 }

--- a/src/screens/FeedsManager/FeedsManagerCard.tsx
+++ b/src/screens/FeedsManager/FeedsManagerCard.tsx
@@ -90,7 +90,7 @@ export const FeedsManagerCard = ({ manager }: Props) => {
             open={Boolean(anchorEl)}
             onClose={handleClose}
           >
-            <MenuItemLink to="/feeds_manager/edit">
+            <MenuItemLink to="/job_distributors/edit">
               <ListItemIcon>
                 <EditIcon />
               </ListItemIcon>

--- a/src/screens/FeedsManager/FeedsManagerScreen.test.tsx
+++ b/src/screens/FeedsManager/FeedsManagerScreen.test.tsx
@@ -44,7 +44,7 @@ describe('FeedsManagerScreen', () => {
 
     renderComponent(mocks)
 
-    expect(await findByText('Feeds Manager')).toBeInTheDocument()
+    expect(await findByText('Job Distributors')).toBeInTheDocument()
     expect(await findByText('Job Proposals')).toBeInTheDocument()
   })
 

--- a/src/screens/FeedsManager/FeedsManagerScreen.test.tsx
+++ b/src/screens/FeedsManager/FeedsManagerScreen.test.tsx
@@ -20,7 +20,7 @@ function renderComponent(mocks: MockedResponse[]) {
         </MockedProvider>
       </Route>
 
-      <Route path="/feeds_manager/new">Redirect Success</Route>
+      <Route path="/job_distributors/new">Redirect Success</Route>
     </>,
   )
 }

--- a/src/screens/FeedsManager/FeedsManagerScreen.tsx
+++ b/src/screens/FeedsManager/FeedsManagerScreen.tsx
@@ -36,7 +36,7 @@ export const FeedsManagerScreen: React.FC = () => {
   return (
     <Redirect
       to={{
-        pathname: '/feeds_manager/new',
+        pathname: '/job_distributors/new',
         state: { from: location },
       }}
     />

--- a/src/screens/FeedsManager/FeedsManagerView.test.tsx
+++ b/src/screens/FeedsManager/FeedsManagerView.test.tsx
@@ -18,7 +18,7 @@ describe('FeedsManagerView', () => {
       </MockedProvider>,
     )
 
-    expect(await findByText('Feeds Manager')).toBeInTheDocument()
+    expect(await findByText('Job Distributors')).toBeInTheDocument()
     expect(await findByText('Job Proposals')).toBeInTheDocument()
   })
 })

--- a/src/screens/FeedsManager/FeedsManagerView.tsx
+++ b/src/screens/FeedsManager/FeedsManagerView.tsx
@@ -16,7 +16,7 @@ export const FeedsManagerView: React.FC<Props> = ({ manager }) => {
   return (
     <Grid container spacing={16}>
       <Grid item xs={12}>
-        <Heading1>Feeds Manager</Heading1>
+        <Heading1>Job Distributors</Heading1>
       </Grid>
       <Grid item xs={12}>
         <FeedsManagerCard manager={manager} />

--- a/src/screens/JobProposal/JobProposalScreen.test.tsx
+++ b/src/screens/JobProposal/JobProposalScreen.test.tsx
@@ -36,7 +36,7 @@ function renderComponent(mocks: MockedResponse[]) {
         </MockedProvider>
       </Route>
 
-      <Route exact path="/feeds_manager">
+      <Route exact path="/job_distributors">
         Root Redirect Success
       </Route>
     </>,

--- a/src/screens/JobProposal/JobProposalScreen.tsx
+++ b/src/screens/JobProposal/JobProposalScreen.tsx
@@ -210,7 +210,7 @@ export const JobProposalScreen: React.FC = () => {
       const payload = result.data?.approveJobProposalSpec
       switch (payload?.__typename) {
         case 'ApproveJobProposalSpecSuccess':
-          history.push('/feeds_manager')
+          history.push('/job_distributors')
 
           setTimeout(() => dispatch(notifySuccessMsg('Spec approved')), 200)
 

--- a/src/screens/NewFeedsManager/NewFeedsManagerScreen.test.tsx
+++ b/src/screens/NewFeedsManager/NewFeedsManagerScreen.test.tsx
@@ -56,7 +56,7 @@ describe('NewFeedsManagerScreen', () => {
 
     await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'))
 
-    expect(await findByText('Register Feeds Manager')).toBeInTheDocument()
+    expect(await findByText('Register Job Distributor')).toBeInTheDocument()
     expect(await findByTestId('feeds-manager-form')).toBeInTheDocument()
   })
 
@@ -141,7 +141,7 @@ describe('NewFeedsManagerScreen', () => {
 
     userEvent.click(getByRole('button', { name: /submit/i }))
 
-    expect(await findByText('Feeds Manager Created')).toBeInTheDocument()
+    expect(await findByText('Job Distributor Created')).toBeInTheDocument()
     expect(await findByText('Redirect Success')).toBeInTheDocument()
   })
 

--- a/src/screens/NewFeedsManager/NewFeedsManagerScreen.test.tsx
+++ b/src/screens/NewFeedsManager/NewFeedsManagerScreen.test.tsx
@@ -30,7 +30,7 @@ function renderComponent(mocks: MockedResponse[]) {
         </MockedProvider>
       </Route>
 
-      <Route path="/feeds_manager">Redirect Success</Route>
+      <Route path="/job_distributors">Redirect Success</Route>
     </>,
   )
 }

--- a/src/screens/NewFeedsManager/NewFeedsManagerScreen.tsx
+++ b/src/screens/NewFeedsManager/NewFeedsManagerScreen.tsx
@@ -91,7 +91,7 @@ export const NewFeedsManagerScreen: React.FC = () => {
         case 'CreateFeedsManagerSuccess':
           history.push('/feeds_manager')
 
-          dispatch(notifySuccessMsg('Feeds Manager Created'))
+          dispatch(notifySuccessMsg('Job Distributor Created'))
 
           break
         case 'SingleFeedsManagerError':

--- a/src/screens/NewFeedsManager/NewFeedsManagerScreen.tsx
+++ b/src/screens/NewFeedsManager/NewFeedsManagerScreen.tsx
@@ -89,7 +89,7 @@ export const NewFeedsManagerScreen: React.FC = () => {
       const payload = result.data?.createFeedsManager
       switch (payload?.__typename) {
         case 'CreateFeedsManagerSuccess':
-          history.push('/feeds_manager')
+          history.push('/job_distributors')
 
           dispatch(notifySuccessMsg('Job Distributor Created'))
 
@@ -115,7 +115,7 @@ export const NewFeedsManagerScreen: React.FC = () => {
     return (
       <Redirect
         to={{
-          pathname: '/feeds_manager',
+          pathname: '/job_distributors',
           state: { from: location },
         }}
       />

--- a/src/screens/NewFeedsManager/NewFeedsManagerView.test.tsx
+++ b/src/screens/NewFeedsManager/NewFeedsManagerView.test.tsx
@@ -12,7 +12,7 @@ describe('NewFeedsManagerView', () => {
 
     render(<NewFeedsManagerView onSubmit={handleSubmit} />)
 
-    expect(getByText('Register Feeds Manager')).toBeInTheDocument()
+    expect(getByText('Register Job Distributor')).toBeInTheDocument()
     expect(getByTestId('feeds-manager-form')).toHaveFormValues({
       name: 'Chainlink Feeds Manager',
       uri: '',

--- a/src/screens/NewFeedsManager/NewFeedsManagerView.tsx
+++ b/src/screens/NewFeedsManager/NewFeedsManagerView.tsx
@@ -23,7 +23,7 @@ export const NewFeedsManagerView: React.FC<Props> = ({ onSubmit }) => {
     <Grid container>
       <Grid item xs={12} md={11} lg={9}>
         <Card>
-          <CardHeader title="Register Feeds Manager" />
+          <CardHeader title="Register Job Distributor" />
           <CardContent>
             <FeedsManagerForm
               initialValues={initialValues}


### PR DESCRIPTION
## Description

Feeds Manager is an outdated term, now that we are rolling out [Job Distributor](https://github.com/smartcontractkit/job-distributor), we want to start adopting the new name.

We are only performing the rename on a superficial level which is on the UI, the rest including the backend remains untouched to keep things simple.

This is in preparation of the incoming changes to support registering more than job distributor per node.

Note: urls are also renamed eg `localhost/feeds_manager` -> `localhost/job_distributors`


JIRA: https://smartcontract-it.atlassian.net/browse/OPCORE-891

# Checklist
- [x] This PR has an accompanying changeset if needed.


# Testing
<img width="1616" alt="Screenshot 2024-08-28 at 11 17 46 PM" src="https://github.com/user-attachments/assets/8ea16a72-909a-43b2-a4e9-bbca594065b7">

<img width="370" alt="Screenshot 2024-08-28 at 11 18 04 PM" src="https://github.com/user-attachments/assets/2a439e19-a138-427c-b0bc-8a88470666bb">

<img width="1589" alt="Screenshot 2024-08-28 at 11 17 39 PM" src="https://github.com/user-attachments/assets/a07d3cb8-3701-44a9-9c2c-87987571c953">


