### PR TITLE
[OPCORE-858]: fix(NewFeedsManagerScreen): no longer redirect

### DIFF
--- a/.changeset/chilly-garlics-remember.md
+++ b/.changeset/chilly-garlics-remember.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': minor
+---
+
+stop redirect to /job_distributors/ when there are registered job distributors

--- a/src/screens/NewFeedsManager/NewFeedsManagerScreen.test.tsx
+++ b/src/screens/NewFeedsManager/NewFeedsManagerScreen.test.tsx
@@ -1,24 +1,20 @@
 import * as React from 'react'
 
+import { MockedProvider, MockedResponse } from '@apollo/client/testing'
+import userEvent from '@testing-library/user-event'
 import { GraphQLError } from 'graphql'
 import { Route } from 'react-router-dom'
-import {
-  renderWithRouter,
-  screen,
-  waitForElementToBeRemoved,
-} from 'support/test-utils'
-import userEvent from '@testing-library/user-event'
-import { MockedProvider, MockedResponse } from '@apollo/client/testing'
+import { renderWithRouter, screen } from 'support/test-utils'
 
-import { buildFeedsManager } from 'support/factories/gql/fetchFeedsManagers'
+import Notifications from 'pages/Notifications'
 import { FEEDS_MANAGERS_QUERY } from 'src/hooks/queries/useFeedsManagersQuery'
+import { buildFeedsManager } from 'support/factories/gql/fetchFeedsManagers'
 import {
   CREATE_FEEDS_MANAGER_MUTATION,
   NewFeedsManagerScreen,
 } from './NewFeedsManagerScreen'
-import Notifications from 'pages/Notifications'
 
-const { findByTestId, findByText, getByRole } = screen
+const { findByTestId, findByText, getByRole, getByText, getByTestId } = screen
 
 function renderComponent(mocks: MockedResponse[]) {
   renderWithRouter(
@@ -37,66 +33,14 @@ function renderComponent(mocks: MockedResponse[]) {
 
 describe('NewFeedsManagerScreen', () => {
   it('renders the page', async () => {
-    const mocks: MockedResponse[] = [
-      {
-        request: {
-          query: FEEDS_MANAGERS_QUERY,
-        },
-        result: {
-          data: {
-            feedsManagers: {
-              results: [],
-            },
-          },
-        },
-      },
-    ]
+    renderComponent([])
 
-    renderComponent(mocks)
-
-    await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'))
-
-    expect(await findByText('Register Job Distributor')).toBeInTheDocument()
-    expect(await findByTestId('feeds-manager-form')).toBeInTheDocument()
-  })
-
-  it('redirects when a manager exists', async () => {
-    const mocks: MockedResponse[] = [
-      {
-        request: {
-          query: FEEDS_MANAGERS_QUERY,
-        },
-        result: {
-          data: {
-            feedsManagers: {
-              results: [buildFeedsManager()],
-            },
-          },
-        },
-      },
-    ]
-
-    renderComponent(mocks)
-
-    await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'))
-
-    expect(await findByText('Redirect Success')).toBeInTheDocument()
+    expect(getByText('Register Job Distributor')).toBeInTheDocument()
+    expect(getByTestId('feeds-manager-form')).toBeInTheDocument()
   })
 
   it('submits the form', async () => {
     const mocks: MockedResponse[] = [
-      {
-        request: {
-          query: FEEDS_MANAGERS_QUERY,
-        },
-        result: {
-          data: {
-            feedsManagers: {
-              results: [],
-            },
-          },
-        },
-      },
       {
         request: {
           query: CREATE_FEEDS_MANAGER_MUTATION,
@@ -133,8 +77,6 @@ describe('NewFeedsManagerScreen', () => {
 
     renderComponent(mocks)
 
-    await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'))
-
     // Note: The name input has a default value so we don't have to set it
     userEvent.type(getByRole('textbox', { name: 'URI *' }), 'localhost:8080')
     userEvent.type(getByRole('textbox', { name: 'Public Key *' }), '1111')
@@ -147,18 +89,6 @@ describe('NewFeedsManagerScreen', () => {
 
   it('handles input errors', async () => {
     const mocks: MockedResponse[] = [
-      {
-        request: {
-          query: FEEDS_MANAGERS_QUERY,
-        },
-        result: {
-          data: {
-            feedsManagers: {
-              results: [],
-            },
-          },
-        },
-      },
       {
         request: {
           query: CREATE_FEEDS_MANAGER_MUTATION,
@@ -201,8 +131,6 @@ describe('NewFeedsManagerScreen', () => {
 
     renderComponent(mocks)
 
-    await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'))
-
     // Note: The name input has a default value so we don't have to set it
     userEvent.type(getByRole('textbox', { name: 'URI *' }), 'localhost:8080')
     userEvent.type(getByRole('textbox', { name: 'Public Key *' }), '1111')
@@ -215,37 +143,8 @@ describe('NewFeedsManagerScreen', () => {
     )
   })
 
-  it('renders query GQL errors', async () => {
-    const mocks: MockedResponse[] = [
-      {
-        request: {
-          query: FEEDS_MANAGERS_QUERY,
-        },
-        result: {
-          errors: [new GraphQLError('Error!')],
-        },
-      },
-    ]
-
-    renderComponent(mocks)
-
-    expect(await findByText('Error: Error!')).toBeInTheDocument()
-  })
-
   it('renders mutation GQL errors', async () => {
     const mocks: MockedResponse[] = [
-      {
-        request: {
-          query: FEEDS_MANAGERS_QUERY,
-        },
-        result: {
-          data: {
-            feedsManagers: {
-              results: [],
-            },
-          },
-        },
-      },
       {
         request: {
           query: CREATE_FEEDS_MANAGER_MUTATION,
@@ -264,8 +163,6 @@ describe('NewFeedsManagerScreen', () => {
     ]
 
     renderComponent(mocks)
-
-    await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'))
 
     userEvent.type(getByRole('textbox', { name: 'URI *' }), 'localhost:8080')
     userEvent.type(getByRole('textbox', { name: 'Public Key *' }), '1111')


### PR DESCRIPTION
## Description

The current behaviour is when we navigate to `job_distributors/new` page, if there is at least 1 registered job distributor, it will redirect to `/job_distributors`. We want to stop redirecting to `/job_distributors` in this scenario since we now want to support adding more than 1 manager.

JIRA: https://smartcontract-it.atlassian.net/browse/OPCORE-858

# Checklist


- [x] This PR has an accompanying changeset if needed.
