### PR TITLE
[DPA-1155]: feat(chainconfig): support aptos

### DIFF
--- a/.changeset/serious-turtles-fold.md
+++ b/.changeset/serious-turtles-fold.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': minor
+---
+
+Support APTOS in chain config

--- a/src/components/Form/ChainConfigurationForm.test.tsx
+++ b/src/components/Form/ChainConfigurationForm.test.tsx
@@ -1,45 +1,25 @@
 import * as React from 'react'
 
-import { render, screen } from 'support/test-utils'
 import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from 'support/test-utils'
 
 import { ChainConfigurationForm, FormValues } from './ChainConfigurationForm'
+import { ChainTypes } from './ChainTypes'
 
 const { getByRole, findByTestId } = screen
 
 describe('ChainConfigurationForm', () => {
   it('validates top level input', async () => {
     const handleSubmit = jest.fn()
-    const initialValues: FormValues = {
-      chainID: '',
-      chainType: '',
-      accountAddr: '',
-      adminAddr: '',
-      fluxMonitorEnabled: false,
-      ocr1Enabled: false,
-      ocr1IsBootstrap: false,
-      ocr1Multiaddr: '',
-      ocr1P2PPeerID: '',
-      ocr1KeyBundleID: '',
-      ocr2Enabled: false,
-      ocr2IsBootstrap: false,
-      ocr2Multiaddr: '',
-      ocr2P2PPeerID: '',
-      ocr2KeyBundleID: '',
-      ocr2CommitPluginEnabled: false,
-      ocr2ExecutePluginEnabled: false,
-      ocr2MedianPluginEnabled: false,
-      ocr2MercuryPluginEnabled: false,
-      ocr2RebalancerPluginEnabled: false,
-      ocr2ForwarderAddress: '',
-    }
+    const initialValues = emptyFormValues()
 
     render(
       <ChainConfigurationForm
         initialValues={initialValues}
         onSubmit={handleSubmit}
-        accounts={[]}
-        chainIDs={[]}
+        accountsEVM={[]}
+        accountsAptos={[]}
+        chains={[]}
         p2pKeys={[]}
         ocrKeys={[]}
         ocr2Keys={[]}
@@ -62,37 +42,15 @@ describe('ChainConfigurationForm', () => {
 
   it('validates OCR input', async () => {
     const handleSubmit = jest.fn()
-    const initialValues: FormValues = {
-      chainID: '',
-      chainType: '',
-      accountAddr: '',
-      accountAddrPubKey: '',
-      adminAddr: '',
-      fluxMonitorEnabled: false,
-      ocr1Enabled: false,
-      ocr1IsBootstrap: false,
-      ocr1Multiaddr: '',
-      ocr1P2PPeerID: '',
-      ocr1KeyBundleID: '',
-      ocr2Enabled: false,
-      ocr2IsBootstrap: false,
-      ocr2Multiaddr: '',
-      ocr2P2PPeerID: '',
-      ocr2KeyBundleID: '',
-      ocr2CommitPluginEnabled: false,
-      ocr2ExecutePluginEnabled: false,
-      ocr2MedianPluginEnabled: false,
-      ocr2MercuryPluginEnabled: false,
-      ocr2RebalancerPluginEnabled: false,
-      ocr2ForwarderAddress: '',
-    }
+    const initialValues = emptyFormValues()
 
     render(
       <ChainConfigurationForm
         initialValues={initialValues}
         onSubmit={handleSubmit}
-        accounts={[]}
-        chainIDs={[]}
+        accountsEVM={[]}
+        accountsAptos={[]}
+        chains={[]}
         p2pKeys={[]}
         ocrKeys={[]}
         ocr2Keys={[]}
@@ -123,37 +81,15 @@ describe('ChainConfigurationForm', () => {
 
   it('validates OCR2 input', async () => {
     const handleSubmit = jest.fn()
-    const initialValues: FormValues = {
-      chainID: '',
-      chainType: '',
-      accountAddr: '',
-      accountAddrPubKey: '',
-      adminAddr: '',
-      fluxMonitorEnabled: false,
-      ocr1Enabled: false,
-      ocr1IsBootstrap: false,
-      ocr1Multiaddr: '',
-      ocr1P2PPeerID: '',
-      ocr1KeyBundleID: '',
-      ocr2Enabled: false,
-      ocr2IsBootstrap: false,
-      ocr2Multiaddr: '',
-      ocr2P2PPeerID: '',
-      ocr2KeyBundleID: '',
-      ocr2CommitPluginEnabled: false,
-      ocr2ExecutePluginEnabled: false,
-      ocr2MedianPluginEnabled: false,
-      ocr2MercuryPluginEnabled: false,
-      ocr2RebalancerPluginEnabled: false,
-      ocr2ForwarderAddress: '',
-    }
+    const initialValues = emptyFormValues()
 
     render(
       <ChainConfigurationForm
         initialValues={initialValues}
         onSubmit={handleSubmit}
-        accounts={[]}
-        chainIDs={[]}
+        accountsEVM={[]}
+        accountsAptos={[]}
+        chains={[]}
         p2pKeys={[]}
         ocrKeys={[]}
         ocr2Keys={[]}
@@ -185,4 +121,128 @@ describe('ChainConfigurationForm', () => {
       await findByTestId('ocr2P2PPeerID-helper-text'),
     ).not.toHaveTextContent('Required')
   })
+
+  test('should able to create APTOS chain config', async () => {
+    const handleSubmit = jest.fn()
+    const initialValues = emptyFormValues()
+    initialValues.chainType = ChainTypes.EVM
+    initialValues.adminAddr = '0x1234567'
+
+    const { container } = render(
+      <ChainConfigurationForm
+        initialValues={initialValues}
+        onSubmit={(x, _) => handleSubmit(x)}
+        accountsEVM={[
+          {
+            address: '0x1111',
+            chain: {
+              id: '1111',
+            },
+            createdAt: '2021-10-06T00:00:00Z',
+            isDisabled: false,
+          },
+        ]}
+        accountsAptos={[
+          {
+            account: '0x123',
+            id: '2222',
+          },
+        ]}
+        chains={[
+          {
+            id: '1111',
+            enabled: true,
+            network: 'evm',
+          },
+          {
+            id: '2222',
+            enabled: true,
+            network: 'aptos',
+          },
+        ]}
+        p2pKeys={[]}
+        ocrKeys={[]}
+        ocr2Keys={[]}
+        showSubmit
+      />,
+    )
+
+    const chainType = getByRole('button', { name: 'EVM' })
+    userEvent.click(chainType)
+    userEvent.click(getByRole('option', { name: 'APTOS' }))
+    await screen.findByRole('button', { name: 'APTOS' })
+
+    // no easy way to use react testing framework to do what i want,
+    // had to resort to using #id and querySelector
+    // formik does not seem to work well with react testing framework
+    const chainId = container.querySelector('#select-chainID')
+    expect(chainId).toBeInTheDocument()
+    // workaround ts lint warning - unable to use chainId!
+    chainId && userEvent.click(chainId)
+    userEvent.click(getByRole('option', { name: '2222' }))
+    await screen.findByRole('button', { name: '2222' })
+
+    const address = container.querySelector('#select-accountAddr')
+    expect(address).toBeInTheDocument()
+    address && userEvent.click(address)
+    userEvent.click(getByRole('option', { name: '0x123' }))
+    await screen.findByRole('button', { name: '0x123' })
+
+    await userEvent.click(getByRole('button', { name: /submit/i }))
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith({
+        accountAddr: '0x123',
+        accountAddrPubKey: '',
+        adminAddr: '0x1234567',
+        chainID: '2222',
+        chainType: 'APTOS',
+        fluxMonitorEnabled: false,
+        ocr1Enabled: false,
+        ocr1IsBootstrap: false,
+        ocr1KeyBundleID: '',
+        ocr1Multiaddr: '',
+        ocr1P2PPeerID: '',
+        ocr2CommitPluginEnabled: false,
+        ocr2Enabled: false,
+        ocr2ExecutePluginEnabled: false,
+        ocr2ForwarderAddress: '',
+        ocr2IsBootstrap: false,
+        ocr2KeyBundleID: '',
+        ocr2MedianPluginEnabled: false,
+        ocr2MercuryPluginEnabled: false,
+        ocr2Multiaddr: '',
+        ocr2P2PPeerID: '',
+        ocr2RebalancerPluginEnabled: false,
+      })
+      expect(handleSubmit).toHaveBeenCalledTimes(1)
+    })
+  })
 })
+
+function emptyFormValues(): FormValues {
+  return {
+    chainID: '',
+    chainType: '',
+    accountAddr: '',
+    accountAddrPubKey: '',
+    adminAddr: '',
+    fluxMonitorEnabled: false,
+    ocr1Enabled: false,
+    ocr1IsBootstrap: false,
+    ocr1Multiaddr: '',
+    ocr1P2PPeerID: '',
+    ocr1KeyBundleID: '',
+    ocr2Enabled: false,
+    ocr2IsBootstrap: false,
+    ocr2Multiaddr: '',
+    ocr2P2PPeerID: '',
+    ocr2KeyBundleID: '',
+    ocr2CommitPluginEnabled: false,
+    ocr2ExecutePluginEnabled: false,
+    ocr2MedianPluginEnabled: false,
+    ocr2MercuryPluginEnabled: false,
+    ocr2RebalancerPluginEnabled: false,
+    ocr2ForwarderAddress: '',
+  }
+}

--- a/src/components/Form/ChainTypes.ts
+++ b/src/components/Form/ChainTypes.ts
@@ -1,0 +1,7 @@
+export const ChainTypes = {
+  EVM: 'EVM',
+  APTOS: 'APTOS',
+  SOLANA: 'SOLANA',
+  STARKNET: 'STARKNET',
+  COSMOS: 'COSMOS',
+}

--- a/src/hooks/queries/useAptosAccountsQuery.test.tsx
+++ b/src/hooks/queries/useAptosAccountsQuery.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing'
+import {
+  useAptosAccountsQuery,
+  APTOS_KEYS_QUERY,
+} from './useAptosAccountsQuery'
+
+const mockData = {
+  data: {
+    aptosKeys: {
+      __typename: 'AptosKeys',
+      results: [
+        { __typename: 'AptosKey', account: 'account1', id: '1' },
+        { __typename: 'AptosKey', account: 'account2', id: '2' },
+      ],
+    },
+  },
+}
+
+const mocks = [
+  {
+    request: {
+      query: APTOS_KEYS_QUERY,
+    },
+    result: mockData,
+  },
+]
+
+const TestComponent: React.FC = () => {
+  const { data, loading, error } = useAptosAccountsQuery()
+
+  if (loading) return <p>Loading... </p>
+  if (error) return <p>Error: {error.message}</p>
+
+  return (
+    <div>
+      {data?.aptosKeys.results.map((key, i) => (
+        <div key={i}>
+          <p>Account: {key.account}</p>
+          <p>ID: {key.id}</p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+describe('useAptosAccountsQuery', () => {
+  test('renders data with correct graphql query', async () => {
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <TestComponent />
+      </MockedProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Account: account1')).toBeInTheDocument()
+      expect(screen.getByText('ID: 1')).toBeInTheDocument()
+      expect(screen.getByText('Account: account2')).toBeInTheDocument()
+      expect(screen.getByText('ID: 2')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/hooks/queries/useAptosAccountsQuery.ts
+++ b/src/hooks/queries/useAptosAccountsQuery.ts
@@ -1,0 +1,24 @@
+import { gql, QueryHookOptions, useQuery } from '@apollo/client'
+
+export const APTOS_KEYS_PAYLOAD__RESULTS_FIELDS = gql`
+  fragment AptosKeysPayload_ResultsFields on AptosKey {
+    account
+    id
+  }
+`
+
+export const APTOS_KEYS_QUERY = gql`
+  ${APTOS_KEYS_PAYLOAD__RESULTS_FIELDS}
+  query FetchAptosKeys {
+    aptosKeys {
+      results {
+        ...AptosKeysPayload_ResultsFields
+      }
+    }
+  }
+`
+
+// useAptosAccountsQuery fetches the Aptos accounts.
+export const useAptosAccountsQuery = (opts: QueryHookOptions = {}) => {
+  return useQuery<FetchAptosKeys>(APTOS_KEYS_QUERY, opts)
+}

--- a/src/hooks/queries/useChainsQuery.ts
+++ b/src/hooks/queries/useChainsQuery.ts
@@ -4,6 +4,7 @@ export const CHAINS_PAYLOAD__RESULTS_FIELDS = gql`
   fragment ChainsPayload_ResultsFields on Chain {
     id
     enabled
+    network
   }
 `
 

--- a/src/screens/FeedsManager/EditSupportedChainDialog.tsx
+++ b/src/screens/FeedsManager/EditSupportedChainDialog.tsx
@@ -13,9 +13,11 @@ import {
 } from 'src/components/Form/ChainConfigurationForm'
 import { useChainsQuery } from 'src/hooks/queries/useChainsQuery'
 import { useEVMAccountsQuery } from 'src/hooks/queries/useEVMAccountsQuery'
+import { useAptosAccountsQuery } from 'src/hooks/queries/useAptosAccountsQuery'
 import { useP2PKeysQuery } from 'src/hooks/queries/useP2PKeysQuery'
 import { useOCRKeysQuery } from 'src/hooks/queries/useOCRKeysQuery'
 import { useOCR2KeysQuery } from 'src/hooks/queries/useOCR2KeysQuery'
+import { ChainTypes } from 'src/components/Form/ChainTypes'
 
 type Props = {
   cfg: FeedsManager_ChainConfigFields | null
@@ -35,7 +37,11 @@ export const EditSupportedChainDialog = ({
     fetchPolicy: 'network-only',
   })
 
-  const { data: accountData } = useEVMAccountsQuery({
+  const { data: accountDataEVM } = useEVMAccountsQuery({
+    fetchPolicy: 'cache-and-network',
+  })
+
+  const { data: accountDataAptos } = useAptosAccountsQuery({
     fetchPolicy: 'cache-and-network',
   })
 
@@ -57,7 +63,7 @@ export const EditSupportedChainDialog = ({
 
   const initialValues = {
     chainID: cfg.chainID,
-    chainType: 'EVM',
+    chainType: ChainTypes.EVM,
     accountAddr: cfg.accountAddr,
     adminAddr: cfg.adminAddr,
     accountAddrPubKey: cfg.accountAddrPubKey,
@@ -80,11 +86,12 @@ export const EditSupportedChainDialog = ({
     ocr2ForwarderAddress: cfg.ocr2JobConfig.forwarderAddress,
   }
 
-  const chainIDs: string[] = chainData
-    ? chainData.chains.results.map((c) => c.id)
-    : []
+  const chains = chainData ? chainData.chains.results : []
 
-  const accounts = accountData ? accountData.ethKeys.results : []
+  const accountsEVM = accountDataEVM ? accountDataEVM.ethKeys.results : []
+  const accountsAptos = accountDataAptos
+    ? accountDataAptos.aptosKeys.results
+    : []
   const p2pKeys = p2pKeysData ? p2pKeysData.p2pKeys.results : []
   const ocrKeys = ocrKeysData ? ocrKeysData.ocrKeyBundles.results : []
   const ocr2Keys = ocr2KeysData ? ocr2KeysData.ocr2KeyBundles.results : []
@@ -100,8 +107,9 @@ export const EditSupportedChainDialog = ({
           innerRef={formRef}
           initialValues={initialValues}
           onSubmit={onSubmit}
-          chainIDs={chainIDs}
-          accounts={accounts}
+          chains={chains}
+          accountsEVM={accountsEVM}
+          accountsAptos={accountsAptos}
           p2pKeys={p2pKeys}
           ocrKeys={ocrKeys}
           ocr2Keys={ocr2Keys}

--- a/src/screens/FeedsManager/NewSupportedChainDialog.tsx
+++ b/src/screens/FeedsManager/NewSupportedChainDialog.tsx
@@ -13,9 +13,11 @@ import {
 } from 'src/components/Form/ChainConfigurationForm'
 import { useChainsQuery } from 'src/hooks/queries/useChainsQuery'
 import { useEVMAccountsQuery } from 'src/hooks/queries/useEVMAccountsQuery'
+import { useAptosAccountsQuery } from 'src/hooks/queries/useAptosAccountsQuery'
 import { useP2PKeysQuery } from 'src/hooks/queries/useP2PKeysQuery'
 import { useOCRKeysQuery } from 'src/hooks/queries/useOCRKeysQuery'
 import { useOCR2KeysQuery } from 'src/hooks/queries/useOCR2KeysQuery'
+import { ChainTypes } from 'src/components/Form/ChainTypes'
 
 type Props = {
   open: boolean
@@ -29,7 +31,11 @@ export const NewSupportedChainDialog = ({ onClose, open, onSubmit }: Props) => {
     fetchPolicy: 'network-only',
   })
 
-  const { data: accountData } = useEVMAccountsQuery({
+  const { data: accountDataEVM } = useEVMAccountsQuery({
+    fetchPolicy: 'cache-and-network',
+  })
+
+  const { data: accountDataAptos } = useAptosAccountsQuery({
     fetchPolicy: 'cache-and-network',
   })
 
@@ -47,7 +53,7 @@ export const NewSupportedChainDialog = ({ onClose, open, onSubmit }: Props) => {
 
   const initialValues = {
     chainID: '',
-    chainType: 'EVM',
+    chainType: ChainTypes.EVM,
     accountAddr: '',
     adminAddr: '',
     accountAddrPubKey: '',
@@ -70,11 +76,12 @@ export const NewSupportedChainDialog = ({ onClose, open, onSubmit }: Props) => {
     ocr2ForwarderAddress: '',
   }
 
-  const chainIDs: string[] = chainData
-    ? chainData.chains.results.map((c) => c.id)
-    : []
+  const chains = chainData ? chainData.chains.results : []
 
-  const accounts = accountData ? accountData.ethKeys.results : []
+  const accountsEVM = accountDataEVM ? accountDataEVM.ethKeys.results : []
+  const accountsAptos = accountDataAptos
+    ? accountDataAptos.aptosKeys.results
+    : []
   const p2pKeys = p2pKeysData ? p2pKeysData.p2pKeys.results : []
   const ocrKeys = ocrKeysData ? ocrKeysData.ocrKeyBundles.results : []
   const ocr2Keys = ocr2KeysData ? ocr2KeysData.ocr2KeyBundles.results : []
@@ -90,8 +97,9 @@ export const NewSupportedChainDialog = ({ onClose, open, onSubmit }: Props) => {
           innerRef={formRef}
           initialValues={initialValues}
           onSubmit={onSubmit}
-          chainIDs={chainIDs}
-          accounts={accounts}
+          chains={chains}
+          accountsEVM={accountsEVM}
+          accountsAptos={accountsAptos}
           p2pKeys={p2pKeys}
           ocrKeys={ocrKeys}
           ocr2Keys={ocr2Keys}

--- a/support/factories/gql/fetchChains.ts
+++ b/support/factories/gql/fetchChains.ts
@@ -6,6 +6,7 @@ export function buildChain(
     __typename: 'Chain',
     id: '5',
     enabled: true,
+    network: 'EVM',
     ...overrides,
   }
 }


### PR DESCRIPTION
## Description

Allow APTOS to be selected in the chainconfig modal instead of just EVM.

The goal is being able to support APTOS in core node.

JIRA: https://smartcontract-it.atlassian.net/browse/DPA-1155

Pending [this PR](https://github.com/smartcontractkit/chainlink/pull/14718) to be merged for the new `network` field.

### Testing
<img width="753" alt="Screenshot 2024-10-12 at 9 44 41 am" src="https://github.com/user-attachments/assets/7308f4da-7730-41ff-a4e7-490ef7f7242b">


# Checklist

If this PR creates changes to the operator-ui itself, rather than tests, pipeline changes, etc. Then please create a changeset so that a new release is created, and the changelog is updated. See: https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md#what-is-a-changeset

- [x] This PR has an accompanying changeset if needed.
