### PR TITLE
[DPA-1160]: fix(chainconfig): make adminAddr optional

### DIFF
--- a/.changeset/real-zoos-jump.md
+++ b/.changeset/real-zoos-jump.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': minor
+---
+
+chainconfg: make admin address optional

--- a/src/components/Form/ChainConfigurationForm.test.tsx
+++ b/src/components/Form/ChainConfigurationForm.test.tsx
@@ -35,9 +35,6 @@ describe('ChainConfigurationForm', () => {
     expect(await findByTestId('accountAddr-helper-text')).toHaveTextContent(
       'Required',
     )
-    expect(await findByTestId('adminAddr-helper-text')).toHaveTextContent(
-      'Required',
-    )
   })
 
   it('validates OCR input', async () => {

--- a/src/components/Form/ChainConfigurationForm.tsx
+++ b/src/components/Form/ChainConfigurationForm.tsx
@@ -57,7 +57,7 @@ const ValidationSchema = Yup.object().shape({
   chainType: Yup.string().required('Required'),
   accountAddr: Yup.string().required('Required'),
   accountAddrPubKey: Yup.string().nullable(),
-  adminAddr: Yup.string().required('Required'),
+  adminAddr: Yup.string(),
   ocr1Multiaddr: Yup.string()
     .when(['ocr1Enabled', 'ocr1IsBootstrap'], {
       is: (enabled: boolean, isBootstrap: boolean) => enabled && isBootstrap,
@@ -327,7 +327,6 @@ export const ChainConfigurationForm = withStyles(styles)(
                     id="adminAddr"
                     name="adminAddr"
                     label="Admin Address"
-                    required
                     fullWidth
                     helperText="The address used for LINK payments"
                     FormHelperTextProps={{


### PR DESCRIPTION

## Description

Making admin address field on the chain config popup optional instead of required, now that we introduced APTOS support on the popup, APTOS does not require admin address.

No changes to the backend required as it happily accepts empty string as a valid value.

I did a quick investigation on what happens if admin address is empty when passed into CLO & JD, looks like the field just get passed along, so if we dont provide a value, nothing happens. It jus shows empty value when user looks it up from the API.

JIRA: https://smartcontract-it.atlassian.net/browse/DPA-1160

## Steps to Test

1. `yarn && yarn setup`
2. `yarn start`
3. ...etc

# Checklist

If this PR creates changes to the operator-ui itself, rather than tests, pipeline changes, etc. Then please create a changeset so that a new release is created, and the changelog is updated. See: https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md#what-is-a-changeset

- [x] This PR has an accompanying changeset if needed.
