### PR TITLE
[DPA-1306]: fix(chain-config): allow manual input

### DIFF
--- a/.changeset/strong-ads-jump.md
+++ b/.changeset/strong-ads-jump.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': minor
+---
+
+#updated chain config: allow chain id and account address to be manually provided when no selections are available

--- a/src/components/Form/ChainConfigurationForm.tsx
+++ b/src/components/Form/ChainConfigurationForm.tsx
@@ -257,6 +257,10 @@ export const ChainConfigurationForm = withStyles(styles)(
             default:
               chainAccountAddresses = []
           }
+
+          const filteredChainIds = chains.filter(
+            (x) => x.network.toUpperCase() === values.chainType,
+          )
           return (
             <Form
               data-testid="feeds-manager-form"
@@ -289,48 +293,77 @@ export const ChainConfigurationForm = withStyles(styles)(
                 </Grid>
 
                 <Grid item xs={12} md={6}>
-                  <Field
-                    component={TextField}
-                    id="chainID"
-                    name="chainID"
-                    label="Chain ID"
-                    required
-                    fullWidth
-                    select
-                    disabled={editing}
-                    inputProps={{ 'data-testid': 'chainID-input' }}
-                    FormHelperTextProps={{
-                      'data-testid': 'chainID-helper-text',
-                    }}
-                  >
-                    {chains
-                      .filter(
-                        (x) => x.network.toUpperCase() === values.chainType,
-                      )
-                      .map((x) => (
+                  {/* always show normal manual input field instead of selection if field is readonly (during editing) */}
+                  {filteredChainIds.length > 0 && !editing ? (
+                    <Field
+                      component={TextField}
+                      id="chainID"
+                      name="chainID"
+                      label="Chain ID"
+                      required
+                      fullWidth
+                      select
+                      disabled={editing}
+                      inputProps={{ 'data-testid': 'chainID-input' }}
+                      FormHelperTextProps={{
+                        'data-testid': 'chainID-helper-text',
+                      }}
+                    >
+                      {filteredChainIds.map((x) => (
                         <MenuItem key={x.id} value={x.id}>
                           {x.id}
                         </MenuItem>
                       ))}
-                  </Field>
+                    </Field>
+                  ) : (
+                    <Field
+                      component={TextField}
+                      id="chainID"
+                      name="chainID"
+                      label="Chain ID"
+                      required
+                      fullWidth
+                      disabled={editing}
+                      inputProps={{ 'data-testid': 'chainID-manual-input' }}
+                      FormHelperTextProps={{
+                        'data-testid': 'chainID-helper-manual-text',
+                      }}
+                    />
+                  )}
                 </Grid>
 
                 <Grid item xs={12} md={6}>
-                  <AccountAddrField
-                    component={TextField}
-                    id="accountAddr"
-                    name="accountAddr"
-                    label="Account Address"
-                    inputProps={{ 'data-testid': 'accountAddr-input' }}
-                    required
-                    fullWidth
-                    select
-                    helperText="The account address used for this chain"
-                    addresses={chainAccountAddresses}
-                    FormHelperTextProps={{
-                      'data-testid': 'accountAddr-helper-text',
-                    }}
-                  />
+                  {chainAccountAddresses.length > 0 ? (
+                    <AccountAddrField
+                      component={TextField}
+                      id="accountAddr"
+                      name="accountAddr"
+                      label="Account Address"
+                      inputProps={{ 'data-testid': 'accountAddr-input' }}
+                      required
+                      fullWidth
+                      select
+                      helperText="The account address used for this chain"
+                      addresses={chainAccountAddresses}
+                      FormHelperTextProps={{
+                        'data-testid': 'accountAddr-helper-text',
+                      }}
+                    />
+                  ) : (
+                    <Field
+                      component={TextField}
+                      id="accountAddr"
+                      name="accountAddr"
+                      label="Account Address"
+                      inputProps={{ 'data-testid': 'accountAddr-manual-input' }}
+                      required
+                      fullWidth
+                      helperText="The account address used for this chain"
+                      FormHelperTextProps={{
+                        'data-testid': 'accountAddr-helper-manual-text',
+                      }}
+                    />
+                  )}
                 </Grid>
 
                 <Grid item xs={12} md={6}>

--- a/src/screens/FeedsManager/EditSupportedChainDialog.tsx
+++ b/src/screens/FeedsManager/EditSupportedChainDialog.tsx
@@ -14,10 +14,9 @@ import {
 import { useChainsQuery } from 'src/hooks/queries/useChainsQuery'
 import { useEVMAccountsQuery } from 'src/hooks/queries/useEVMAccountsQuery'
 import { useNonEvmAccountsQuery } from 'src/hooks/queries/useNonEvmAccountsQuery'
-import { useP2PKeysQuery } from 'src/hooks/queries/useP2PKeysQuery'
-import { useOCRKeysQuery } from 'src/hooks/queries/useOCRKeysQuery'
 import { useOCR2KeysQuery } from 'src/hooks/queries/useOCR2KeysQuery'
-import { ChainTypes } from 'src/components/Form/ChainTypes'
+import { useOCRKeysQuery } from 'src/hooks/queries/useOCRKeysQuery'
+import { useP2PKeysQuery } from 'src/hooks/queries/useP2PKeysQuery'
 
 type Props = {
   cfg: FeedsManager_ChainConfigFields | null
@@ -63,7 +62,7 @@ export const EditSupportedChainDialog = ({
 
   const initialValues = {
     chainID: cfg.chainID,
-    chainType: ChainTypes.EVM,
+    chainType: cfg.chainType,
     accountAddr: cfg.accountAddr,
     adminAddr: cfg.adminAddr,
     accountAddrPubKey: cfg.accountAddrPubKey,


### PR DESCRIPTION
Allow user to manually input ChainId and Account Address when there are no selections available.

When creating a chain config in operator ui, if the core node is not configured with APTOS RPC, user wont be able to create a chain config because there are nothing to select from in the ChainId and Account Address field in the chain config popup.

This is a new scenario for Keystone where a chain config needs to be created even if there are no existing connection to an RPC.

JIRA: https://smartcontract-it.atlassian.net/browse/DPA-1306

