### PR TITLE
fix: use large limit to fetch all chains in FMS chain

### DIFF
--- a/.changeset/hot-mails-rhyme.md
+++ b/.changeset/hot-mails-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': patch
+---
+
+Increase limit for number of chains in FMS

--- a/src/screens/FeedsManager/EditSupportedChainDialog.tsx
+++ b/src/screens/FeedsManager/EditSupportedChainDialog.tsx
@@ -33,6 +33,7 @@ export const EditSupportedChainDialog = ({
   const formRef = React.useRef()
 
   const { data: chainData } = useChainsQuery({
+    variables: { limit: 999 },
     fetchPolicy: 'network-only',
   })
 

--- a/src/screens/FeedsManager/NewSupportedChainDialog.tsx
+++ b/src/screens/FeedsManager/NewSupportedChainDialog.tsx
@@ -28,6 +28,7 @@ export const NewSupportedChainDialog = ({ onClose, open, onSubmit }: Props) => {
   const formRef = React.useRef()
 
   const { data: chainData } = useChainsQuery({
+    variables: { limit: 999 },
     fetchPolicy: 'network-only',
   })
 


### PR DESCRIPTION
 config dialog

## Description

Increases limit for the number of chains.

## Steps to Test

1. `yarn && yarn setup`
2. `yarn start`
3. `start chainlink node with more than 50 chains`
4. `Login to the UI and add one Job Distributor`
5. `Try to add new supported chain in JD and make sure that all chains are listed in drop down list`

# Checklist

If this PR creates changes to the operator-ui itself, rather than tests, pipeline changes, etc. Then please create a changeset so that a new release is created, and the changelog is updated. See: https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md#what-is-a-changeset

- [x] This PR has an accompanying changeset if needed.
