### PR TITLE
feat: allow approval of previous versions of job specs

### DIFF
--- a/.changeset/flat-toys-roll.md
+++ b/.changeset/flat-toys-roll.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': patch
+---
+
+feat: allow approval of previous versions of job specs

--- a/src/screens/JobProposal/SpecsView.test.tsx
+++ b/src/screens/JobProposal/SpecsView.test.tsx
@@ -267,20 +267,21 @@ describe('SpecsView', () => {
 
     beforeEach(() => {
       specs = [
-        buildJobProposalSpec({ id: '105', version: 5, status: 'CANCELLED' }),
-        buildJobProposalSpec({ id: '104', version: 4, status: 'PENDING' }),
+        buildJobProposalSpec({ id: '106', version: 6, status: 'CANCELLED' }),
+        buildJobProposalSpec({ id: '105', version: 5, status: 'PENDING' }),
+        buildJobProposalSpec({ id: '104', version: 4, status: 'CANCELLED' }),
         buildJobProposalSpec({ id: '103', version: 3, status: 'CANCELLED' }),
         buildJobProposalSpec({ id: '102', version: 2, status: 'APPROVED' }),
         buildJobProposalSpec({ id: '101', version: 1, status: 'REVOKED' }),
       ]
     })
 
-    it('is visible in all cancelled specs if proposal is not deleted or revoked', async () => {
+    it('is visible in latest two cancelled specs if proposal is not deleted or revoked', async () => {
       proposal = buildJobProposal({ status: 'PENDING' })
       renderComponent(specs, proposal)
 
       const panels = screen.getAllByTestId('expansion-panel')
-      expect(panels).toHaveLength(5)
+      expect(panels).toHaveLength(6)
       expect(
         within(panels[0]).queryByRole('button', {
           name: 'Approve',
@@ -311,6 +312,43 @@ describe('SpecsView', () => {
           hidden: true,
         }),
       ).not.toBeInTheDocument()
+      expect(
+        within(panels[5]).queryByRole('button', {
+          name: 'Approve',
+          hidden: true,
+        }),
+      ).not.toBeInTheDocument()
+    })
+
+    it('is visible in latest pending spec if proposal is not deleted or revoked', async () => {
+      specs = [
+        buildJobProposalSpec({ id: '103', version: 3, status: 'PENDING' }),
+        buildJobProposalSpec({ id: '102', version: 2, status: 'PENDING' }),
+        buildJobProposalSpec({ id: '101', version: 1, status: 'CANCELLED' }),
+      ]
+      proposal = buildJobProposal({ status: 'PENDING' })
+      renderComponent(specs, proposal)
+
+      const panels = screen.getAllByTestId('expansion-panel')
+      expect(panels).toHaveLength(3)
+      expect(
+        within(panels[0]).queryByRole('button', {
+          name: 'Approve',
+          hidden: false,
+        }),
+      ).toBeInTheDocument()
+      expect(
+        within(panels[1]).queryByRole('button', {
+          name: 'Approve',
+          hidden: true,
+        }),
+      ).not.toBeInTheDocument()
+      expect(
+        within(panels[2]).queryByRole('button', {
+          name: 'Approve',
+          hidden: true,
+        }),
+      ).toBeInTheDocument()
     })
 
     it('is not visible in any specs if proposal is deleted', async () => {
@@ -318,7 +356,7 @@ describe('SpecsView', () => {
       renderComponent(specs, proposal)
 
       const panels = screen.getAllByTestId('expansion-panel')
-      expect(panels).toHaveLength(5)
+      expect(panels).toHaveLength(6)
       expect(
         screen.queryByRole('button', { name: 'Approve', hidden: false }),
       ).not.toBeInTheDocument()
@@ -329,10 +367,44 @@ describe('SpecsView', () => {
       renderComponent(specs, proposal)
 
       const panels = screen.getAllByTestId('expansion-panel')
-      expect(panels).toHaveLength(5)
+      expect(panels).toHaveLength(6)
       expect(
         screen.queryByRole('button', { name: 'Approve', hidden: false }),
       ).not.toBeInTheDocument()
+    })
+
+    it('is visible with single pending job', async () => {
+      proposal = buildJobProposal({ status: 'PENDING' })
+      specs = [
+        buildJobProposalSpec({ id: '101', version: 1, status: 'PENDING' }),
+      ]
+      renderComponent(specs, proposal)
+
+      const panels = screen.getAllByTestId('expansion-panel')
+      expect(panels).toHaveLength(1)
+      expect(
+        within(panels[0]).queryByRole('button', {
+          name: 'Approve',
+          hidden: false,
+        }),
+      ).toBeInTheDocument()
+    })
+
+    it('is visible with single cancelled job', async () => {
+      proposal = buildJobProposal({ status: 'PENDING' })
+      specs = [
+        buildJobProposalSpec({ id: '101', version: 1, status: 'CANCELLED' }),
+      ]
+      renderComponent(specs, proposal)
+
+      const panels = screen.getAllByTestId('expansion-panel')
+      expect(panels).toHaveLength(1)
+      expect(
+        within(panels[0]).queryByRole('button', {
+          name: 'Approve',
+          hidden: false,
+        }),
+      ).toBeInTheDocument()
     })
   })
 })

--- a/src/screens/JobProposal/SpecsView.tsx
+++ b/src/screens/JobProposal/SpecsView.tsx
@@ -124,6 +124,12 @@ export const SpecsView = withStyles(styles)(
       return sorted.sort((a, b) => b.version - a.version)
     }, [specs])
 
+    const approvableCancelledJobSpecs = sortedSpecs
+      .map((spec, idx) => ({ spec, idx }))
+      .filter((el) => el.spec.status === 'CANCELLED')
+      .slice(0, 2)
+      .map((el) => el.spec.id)
+
     const renderActions = (
       status: SpecStatus,
       specID: string,
@@ -192,7 +198,11 @@ export const SpecsView = withStyles(styles)(
             </>
           )
         case 'CANCELLED':
-          if (proposal.status !== 'DELETED' && proposal.status !== 'REVOKED') {
+          if (
+            approvableCancelledJobSpecs.includes(specID) &&
+            proposal.status !== 'DELETED' &&
+            proposal.status !== 'REVOKED'
+          ) {
             return (
               <Button
                 variant="contained"

--- a/src/screens/JobProposal/SpecsView.tsx
+++ b/src/screens/JobProposal/SpecsView.tsx
@@ -144,10 +144,9 @@ export const SpecsView = withStyles(styles)(
     }, [specs])
 
     const approvableCancelledJobSpecs = sortedSpecs
-      .map((spec, idx) => ({ spec, idx }))
-      .filter((el) => el.spec.status === 'CANCELLED')
+      .filter((spec) => spec.status === 'CANCELLED')
       .slice(0, 2)
-      .map((el) => el.spec.id)
+      .map((spec) => spec.id)
 
     const renderActions = (
       status: SpecStatus,

--- a/src/screens/JobProposal/SpecsView.tsx
+++ b/src/screens/JobProposal/SpecsView.tsx
@@ -228,7 +228,7 @@ export const SpecsView = withStyles(styles)(
                 color="primary"
                 onClick={() =>
                   openConfirmationDialog(
-                    specID == latestSpec.id ? 'approve' : 'approvePrevious',
+                    specID === latestSpec.id ? 'approve' : 'approvePrevious',
                     specID,
                   )
                 }

--- a/src/screens/JobProposal/SpecsView.tsx
+++ b/src/screens/JobProposal/SpecsView.tsx
@@ -72,7 +72,7 @@ interface Props extends WithStyles<typeof styles> {
 }
 
 interface ConfirmationDialogArgs {
-  action: 'reject' | 'approve' | 'cancel'
+  action: 'reject' | 'approve' | 'approvePrevious' | 'cancel'
   id: string
 }
 
@@ -80,6 +80,25 @@ const confirmationDialogText = {
   approve: {
     title: 'Approve Job Proposal',
     body: 'Approving this job proposal will start running a new job. WARNING: If a job using the same contract address already exists, it will be deleted before running the new one.',
+  },
+  approvePrevious: {
+    title: 'Approve Previous Version of Job Proposal',
+    body: (
+      <div>
+        <p>
+          ⚠️ You have selected a job spec version that is not the most recent
+          one.
+        </p>
+        <p>
+          Approving this job proposal will start running a new job with the old
+          spec version.
+        </p>
+        <p>
+          WARNING: If a job using the same contract address already exists, it
+          will be deleted before running the new one.
+        </p>
+      </div>
+    ),
   },
   cancel: {
     title: 'Cancel Job Proposal',
@@ -207,7 +226,12 @@ export const SpecsView = withStyles(styles)(
               <Button
                 variant="contained"
                 color="primary"
-                onClick={() => openConfirmationDialog('approve', specID)}
+                onClick={() =>
+                  openConfirmationDialog(
+                    specID == latestSpec.id ? 'approve' : 'approvePrevious',
+                    specID,
+                  )
+                }
               >
                 Approve
               </Button>
@@ -295,6 +319,7 @@ export const SpecsView = withStyles(styles)(
             if (confirmationDialog) {
               switch (confirmationDialog.action) {
                 case 'approve':
+                case 'approvePrevious':
                   onApprove(confirmationDialog.id)
 
                   break

--- a/src/screens/JobProposal/SpecsView.tsx
+++ b/src/screens/JobProposal/SpecsView.tsx
@@ -192,11 +192,7 @@ export const SpecsView = withStyles(styles)(
             </>
           )
         case 'CANCELLED':
-          if (
-            latestSpec.id === specID &&
-            proposal.status !== 'DELETED' &&
-            proposal.status !== 'REVOKED'
-          ) {
+          if (proposal.status !== 'DELETED' && proposal.status !== 'REVOKED') {
             return (
               <Button
                 variant="contained"
@@ -217,7 +213,11 @@ export const SpecsView = withStyles(styles)(
     return (
       <div>
         {sortedSpecs.map((spec, idx) => (
-          <ExpansionPanel defaultExpanded={idx === 0} key={idx}>
+          <ExpansionPanel
+            defaultExpanded={idx === 0}
+            key={idx}
+            data-testid="expansion-panel"
+          >
             <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
               <Typography className={classes.versionText}>
                 Version {spec.version}


### PR DESCRIPTION
## Description

Display the "Approve" button on the latest two versions of a job spec in the "job proposal details" page that have the "cancelled" status. This allows users to approve older versions of a job spec.

This PR must be deployed along with PR # from the core repo.

[DX-534](https://smartcontract-it.atlassian.net/browse/DX-534)

## Steps to Test

1. `yarn && yarn setup`
2. `yarn start`
3. Select a job proposal that has multiple versions
4. Check that all versions in the "cancelled" state have an `Approve` button
5. Approve an order version of a job spec
6. If there was another job previously in the "approved", an error message should be displayed
7. If needed, cancel the version that is currently approved (likely the newest one)
8. Try to approve an older job spec.
9. If no other version was in the "approved" state, the approval operation should complete successfully

## Checklist

- [x] This PR has an accompanying changeset if needed.

## Screenshots

https://github.com/user-attachments/assets/d978bbd5-52f8-40df-a5a1-781684539566

---
Update after Sebastian's suggestion to limit the set of cancelled specs that can be approved to the last two versions:

(error returned by backend attempting to approve an older spec using the previous patch)
![image](https://github.com/user-attachments/assets/a85015ec-63eb-445a-826b-c7d3fa28050f)

(new UI version; only the last 2 cancelled proposals are "approvable"; a different message is displayed when approving an older spec version)

https://github.com/user-attachments/assets/0db6fe2f-7c84-4652-a664-2c2d7475f400



[DX-534]: https://smartcontract-it.atlassian.net/browse/DX-534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
