### PR TITLE
Add job spec display for CCIP 1.6 and 1.7

### DIFF
--- a/.changeset/stupid-flies-happen.md
+++ b/.changeset/stupid-flies-happen.md
@@ -1,0 +1,5 @@
+---
+'@smartcontractkit/operator-ui': patch
+---
+
+Add CCIP job types.

--- a/src/screens/Job/JobView.tsx
+++ b/src/screens/Job/JobView.tsx
@@ -148,6 +148,21 @@ const JOB_PAYLOAD__SPEC = gql`
     ... on StreamSpec {
       streamID
     }
+    ... on CCIPSpec {
+      p2pv2Bootstrappers
+      capabilityVersion
+      capabilityLabelledName
+      ocrKeyBundleIDs
+      relayConfigs
+      p2pKeyID
+      pluginConfig
+    }
+    ... on CCVCommitteeVerifierSpec {
+      committeeVerifierConfig
+    }
+    ... on CCVExecutorSpec {
+      executorConfig
+    }
   }
 `
 

--- a/src/screens/Job/generateJobDefinition.test.ts
+++ b/src/screens/Job/generateJobDefinition.test.ts
@@ -721,6 +721,122 @@ streamID = "1001"
     expect(output.definition).toEqual(expectedOutput)
   })
 
+  it('generates a valid CCIP definition', () => {
+    const job: JobPayload_Fields = {
+      id: '1',
+      type: 'ccip',
+      schemaVersion: 1,
+      name: 'ccip test',
+      externalJobID: '00000000-0000-0000-0000-0000000000001',
+      maxTaskDuration: '',
+      spec: {
+        __typename: 'CCIPSpec',
+        p2pv2Bootstrappers: ["Luke Skywalker","Darth Vader","Uncle Owen"],
+        capabilityVersion: '9001',
+        capabilityLabelledName: 'El Toro Loco',
+        p2pKeyID: 'Lakitu',
+        ocrKeyBundleIDs: {
+          RedFish: { Color: "Red" },
+          BlueFish: { Color: "Blue" },
+        },
+        relayConfigs: {
+          evm: "evm_key_bundle_id",
+          solana: "solana_key_bundle_id",
+        },
+        pluginConfig: {
+          Commit: {
+            enabled: true,
+          },
+          Executor: {
+            enabled: true,
+          },
+        },
+      },
+      observationSource: '',
+      ...otherJobFields,
+    }
+
+    const expectedOutput = `type = "ccip"
+schemaVersion = 1
+name = "ccip test"
+externalJobID = "00000000-0000-0000-0000-0000000000001"
+p2pV2Bootstrappers = [ "Luke Skywalker", "Darth Vader", "Uncle Owen" ]
+capabilityVersion = "9001"
+capabilityLabelledName = "El Toro Loco"
+p2pKeyID = "Lakitu"
+
+[ocrKeyBundleIDs.RedFish]
+Color = "Red"
+
+[ocrKeyBundleIDs.BlueFish]
+Color = "Blue"
+
+[relayConfigs]
+evm = "evm_key_bundle_id"
+solana = "solana_key_bundle_id"
+
+[pluginConfig.Commit]
+enabled = true
+
+[pluginConfig.Executor]
+enabled = true
+`
+    const output = generateJobDefinition(job)
+    expect(output.definition).toEqual(expectedOutput)
+  })
+
+  it('generates a valid CCVCommitteeVerifier definition', () => {
+    const job: JobPayload_Fields = {
+      id: '1',
+      type: 'ccvcommitteeverifier',
+      schemaVersion: 1,
+      name: 'ccv committee verifier test',
+      externalJobID: '00000000-0000-0000-0000-0000000000001',
+      maxTaskDuration: '',
+      spec: {
+        __typename: 'CCVCommitteeVerifierSpec',
+        committeeVerifierConfig: '{"my": "data"}',
+      },
+      observationSource: '',
+      ...otherJobFields,
+    }
+
+    const expectedOutput = `type = "ccvcommitteeverifier"
+schemaVersion = 1
+name = "ccv committee verifier test"
+externalJobID = "00000000-0000-0000-0000-0000000000001"
+committeeVerifierConfig = '{"my": "data"}'
+`
+    const output = generateJobDefinition(job)
+    expect(output.definition).toEqual(expectedOutput)
+  })
+
+  it('generates a valid CCVExecutor definition', () => {
+    const job: JobPayload_Fields = {
+      id: '1',
+      type: 'ccvexecutor',
+      schemaVersion: 1,
+      name: 'ccv executor test',
+      externalJobID: '00000000-0000-0000-0000-0000000000001',
+      maxTaskDuration: '',
+      spec: {
+        __typename: 'CCVExecutorSpec',
+        executorConfig: '{"my": "data"}',
+      },
+      observationSource: '',
+      ...otherJobFields,
+    }
+
+    const expectedOutput = `type = "ccvexecutor"
+schemaVersion = 1
+name = "ccv executor test"
+externalJobID = "00000000-0000-0000-0000-0000000000001"
+executorConfig = '{"my": "data"}'
+`
+    const output = generateJobDefinition(job)
+    expect(output.definition).toEqual(expectedOutput)
+  })
+
   it('generates an empty definition for unspecified type', () => {
     const job: JobPayload_Fields = {
       id: '',

--- a/src/screens/Job/generateJobDefinition.test.ts
+++ b/src/screens/Job/generateJobDefinition.test.ts
@@ -731,17 +731,17 @@ streamID = "1001"
       maxTaskDuration: '',
       spec: {
         __typename: 'CCIPSpec',
-        p2pv2Bootstrappers: ["Luke Skywalker","Darth Vader","Uncle Owen"],
+        p2pv2Bootstrappers: ['Luke Skywalker', 'Darth Vader', 'Uncle Owen'],
         capabilityVersion: '9001',
         capabilityLabelledName: 'El Toro Loco',
         p2pKeyID: 'Lakitu',
         ocrKeyBundleIDs: {
-          RedFish: { Color: "Red" },
-          BlueFish: { Color: "Blue" },
+          RedFish: { Color: 'Red' },
+          BlueFish: { Color: 'Blue' },
         },
         relayConfigs: {
-          evm: "evm_key_bundle_id",
-          solana: "solana_key_bundle_id",
+          evm: 'evm_key_bundle_id',
+          solana: 'solana_key_bundle_id',
         },
         pluginConfig: {
           Commit: {
@@ -760,7 +760,7 @@ streamID = "1001"
 schemaVersion = 1
 name = "ccip test"
 externalJobID = "00000000-0000-0000-0000-0000000000001"
-p2pV2Bootstrappers = [ "Luke Skywalker", "Darth Vader", "Uncle Owen" ]
+p2pv2Bootstrappers = [ "Luke Skywalker", "Darth Vader", "Uncle Owen" ]
 capabilityVersion = "9001"
 capabilityLabelledName = "El Toro Loco"
 p2pKeyID = "Lakitu"

--- a/src/screens/Job/generateJobDefinition.ts
+++ b/src/screens/Job/generateJobDefinition.ts
@@ -292,6 +292,39 @@ export const generateJobDefinition = (
 
       break
 
+    case 'CCIPSpec':
+      values = {
+        ...extractJobFields(job),
+        ...extractSpecFields(
+          job.spec,
+          'p2pv2Bootstrappers',
+          'capabilityVersion',
+          'capabilityLabelledName',
+          'ocrKeyBundleIDs',
+          'relayConfigs',
+          'p2pKeyID',
+          'pluginConfig',
+        ),
+      }
+
+      break
+
+    case 'CCVCommitteeVerifierSpec':
+      values = {
+        ...extractJobFields(job),
+        ...extractSpecFields(job.spec, 'committeeVerifierConfig'),
+      }
+
+      break
+
+    case 'CCVExecutorSpec':
+      values = {
+        ...extractJobFields(job),
+        ...extractSpecFields(job.spec, 'executorConfig'),
+      }
+
+      break
+
     default:
       return { definition: '' }
   }


### PR DESCRIPTION
## Description

Update operator-ui to use new CCIP schema types.

## Steps to Test

1. `yarn && yarn setup`
2. `yarn start`
3. ...etc

# Checklist
- [X] This PR has an accompanying changeset if needed.

# Screenshots
<img width="1355" height="547" alt="image (4)" src="https://github.com/user-attachments/assets/5af35d0c-cffc-4fbb-bad5-e5a3efedaa5d" />
<img width="1367" height="711" alt="image (6)" src="https://github.com/user-attachments/assets/da91130d-5857-45c6-885c-c1a356d20685" />
<img width="1359" height="589" alt="image (5)" src="https://github.com/user-attachments/assets/b1e9824a-ae0d-4b44-bb63-6939ca8a1c57" />

