### PR TITLE
fix semver dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,15 +128,13 @@
     "lodash": "4.18.1",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
-    "js-yaml": "^3.14.2",
-    "semver": "^6.3.1"
+    "js-yaml": "^3.14.2"
   },
   "overrides": {
     "lodash": "4.18.1",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
-    "js-yaml": "^3.14.2",
-    "semver": "^6.3.1"
+    "js-yaml": "^3.14.2"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9355,10 +9355,15 @@ selfsigned@^5.5.0:
     "@peculiar/x509" "^1.14.2"
     pkijs "^3.3.3"
 
-semver@^6.0.0, semver@^6.3.1, semver@^7.5.3, semver@^7.5.4, semver@^7.6.3, semver@^7.7.2, semver@^7.7.3:
+semver@^6.0.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.5.3, semver@^7.5.4, semver@^7.6.3, semver@^7.7.2, semver@^7.7.3:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.0.tgz#ed0661039fcbcda2ce71f01fa6adbefaa77040df"
+  integrity sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==
 
 send@~0.19.0, send@~0.19.1:
   version "0.19.2"


### PR DESCRIPTION
Semver 7.x is required for some depencies. Locking it to 6.x breaks the release.