### PR TITLE
pin lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "json-api-normalizer": "^1.0.4",
     "json-pretty-html": "^1.1.6",
     "local-storage-fallback": "^4.1.3",
-    "lodash": "^4.18.1",
+    "lodash": "4.18.1",
     "moment": "^2.30.1",
     "path-to-regexp": "^3.3.0",
     "prop-types": "^15.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7786,7 +7786,7 @@ lodash.startcase@^4.4.0:
   resolved "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz"
   integrity sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==
 
-lodash@4.18.1, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.18.1:
+lodash@4.18.1, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==


### PR DESCRIPTION
https://github.com/smartcontractkit/operator-ui/actions/runs/26029140284/job/76510206689

CD was breaking due to the lodash mismatch. This PR locks it to a single version to avoid any mismatches. 